### PR TITLE
[Reviewer Andy] Remove hardcoded reference to cw-ngv.com from off-net number rejection t...

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -68,7 +68,7 @@ class TestDefinition
     @@tests
   end
 
-  def record_failure
+  def self.record_failure
     @@failures += 1
   end
 

--- a/lib/tests/basic-call.rb
+++ b/lib/tests/basic-call.rb
@@ -79,7 +79,7 @@ end
 
 TestDefinition.new("Basic Call - Off-net number rejection") do |t|
   sip_caller = t.add_sip_endpoint
-  sip_callee = t.add_fake_endpoint("+16505551234", "cw-ngv.com")
+  sip_callee = t.add_fake_endpoint("+16505551234", $domain)
 
   t.set_scenario(
     sip_caller.register +


### PR DESCRIPTION
There was a hardcoded reference to cw-ngv.com in the off-net number rejection test case that was causing it to fail.  I've changed this to reference the domain of the system under test instead.  I've tested the fix by running the test suite.  I also found a missing method error while looking at this, so that is fixed up in this pull request as well.
