### PR TITLE
Only ever rescue StandardError, thereby allowing SystemExit to bubble up

### DIFF
--- a/lib/sipp-endpoint.rb
+++ b/lib/sipp-endpoint.rb
@@ -139,7 +139,7 @@ private
                           username: account_username,
                           password: account_password)
       r.cookies
-    rescue
+    rescue StandardError
       # This is most likely caused by the System Test user not existing.  Create it now and retry.
       RestClient.post(ellis_url("accounts"),
                       username: "System Test",

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -86,7 +86,7 @@ class TestDefinition
         begin
           print "#{test.name} (#{trans.to_s.upcase}) - "
           test.run(deployment, trans)
-        rescue Exception => e
+        rescue StandardError => e
           record_failure
           puts RedGreen::Color.red("Failed")
           puts "  #{e.class} thrown:"


### PR DESCRIPTION
This allows Ctrl+C to kill the live test immediately.
