### PR TITLE
Remove code for handling unchallenged registers

### DIFF
--- a/lib/sipp-endpoint.rb
+++ b/lib/sipp-endpoint.rb
@@ -68,30 +68,26 @@ class SIPpEndpoint
     SIPpPhase.new("__play_audio", self, options.merge(audio: audio, track_length: length))
   end
 
-  def register(auth_reqd = true)
+  def register
     label_id = TestDefinition.get_next_label_id
     register_flow = []
-    if auth_reqd
-      register_flow << send("REGISTER")
-      if @transport == :tcp
-        register_flow << recv("401", save_auth: true)
-      elsif @transport == :udp
-        # In some situations, bono will allow a message through if the IP, port
-        # and username match a recent REGISTER.  Since ellis allocates numbers
-        # pretty deterministically, this happens quite often.
-        register_flow << recv("200", optional: true, next_label: label_id, save_nat_ip: true)
-        register_flow << recv("401", save_auth: true)
-      else
-        throw "Unrecognized transport #{@transport}"
-      end
-      register_flow << send("REGISTER", auth_header: true)
+    register_flow << send("REGISTER")
+
+    if @transport == :tcp
+      register_flow << recv("401", save_auth: true)
+    elsif @transport == :udp
+      # In some situations, bono will allow a message through if the IP, port
+      # and username match a recent REGISTER.  Since ellis allocates numbers
+      # pretty deterministically, this happens quite often.
+      register_flow << recv("200", optional: true, next_label: label_id, save_nat_ip: true)
+      register_flow << recv("401", save_auth: true)
     else
-      register_flow << send("REGISTER")
+      throw "Unrecognized transport #{@transport}"
     end
+
+    register_flow << send("REGISTER", auth_header: true)
     register_flow << recv("200", save_nat_ip: true)
     register_flow << SIPpPhase.new("__label", self, label_value: label_id)
-#    register_flow << send("REGISTER", nat_contact_header: true)
-#    register_flow << recv("200")
     register_flow
   end
 

--- a/lib/tests/basic-call.rb
+++ b/lib/tests/basic-call.rb
@@ -37,7 +37,7 @@ TestDefinition.new("Basic Call - Mainline") do |t|
   sip_callee = t.add_sip_endpoint
   t.set_scenario(
     sip_caller.register +
-    sip_callee.register(false) +
+    sip_callee.register +
     [
       sip_caller.send("INVITE", target: sip_callee, emit_trusted: true),
       sip_caller.recv("100"),
@@ -99,7 +99,7 @@ TestDefinition.new("Basic Call - Rejected by remote endpoint") do |t|
 
   t.set_scenario(
     sip_caller.register +
-    sip_callee.register(false) +
+    sip_callee.register +
     [
       sip_caller.send("INVITE", target: sip_callee),
       sip_caller.recv("100"),

--- a/lib/tests/call-barring.rb
+++ b/lib/tests/call-barring.rb
@@ -41,7 +41,7 @@ TestDefinition.new("Call Barring - Outbound Rejection") do |t|
   sip_callee = t.add_sip_endpoint
   t.set_scenario(
     sip_caller.register +
-    sip_callee.register(false) +
+    sip_callee.register +
     [
       sip_caller.send("INVITE", target: sip_callee),
       sip_caller.recv("100"),
@@ -62,7 +62,7 @@ PSTNTestDefinition.new("Call Barring - Allow non-international call") do |t|
   sip_callee = t.add_sip_endpoint
   t.set_scenario(
     sip_caller.register +
-    sip_callee.register(false) +
+    sip_callee.register +
     [
       sip_caller.send("INVITE", target: sip_callee),
       sip_caller.recv("100"),
@@ -113,7 +113,7 @@ TestDefinition.new("Call Barring - Inbound Rejection") do |t|
                                }
   t.set_scenario(
     sip_caller.register +
-    sip_callee.register(false) +
+    sip_callee.register +
     [
       sip_caller.send("INVITE", target: sip_callee),
       sip_caller.recv("100"),

--- a/lib/tests/call-diversion.rb
+++ b/lib/tests/call-diversion.rb
@@ -43,7 +43,7 @@ TestDefinition.new("Call Diversion - Not registered") do |t|
                                 }
   t.set_scenario(
     sip_caller.register +
-    sip_callee2.register(false) +
+    sip_callee2.register +
     [
       sip_caller.send("INVITE", target: sip_callee1),
       sip_caller.recv("100"),
@@ -78,8 +78,8 @@ TestDefinition.new("Call Diversion - Busy") do |t|
                                 }
   t.set_scenario(
     sip_caller.register +
-    sip_callee1.register(false) +
-    sip_callee2.register(false) +
+    sip_callee1.register +
+    sip_callee2.register +
     [
       sip_caller.send("INVITE", target: sip_callee1),
       sip_caller.recv("100"),
@@ -120,8 +120,8 @@ TestDefinition.new("Call Diversion - No answer") do |t|
                                 }
   t.set_scenario(
     sip_caller.register +
-    sip_callee1.register(false) +
-    sip_callee2.register(false) +
+    sip_callee1.register +
+    sip_callee2.register +
     [
       sip_caller.send("INVITE", target: sip_callee1),
       sip_caller.recv("100"),

--- a/lib/tests/cancel.rb
+++ b/lib/tests/cancel.rb
@@ -37,7 +37,7 @@ TestDefinition.new("CANCEL - Mainline") do |t|
   sip_callee = t.add_sip_endpoint
   t.set_scenario(
     sip_caller.register +
-    sip_callee.register(false) +
+    sip_callee.register +
     [
       sip_caller.send("INVITE", target: sip_callee),
       sip_caller.recv("100"),


### PR DESCRIPTION
This requires my changes in bono to remember authenticated AoRs.  Remove the code that allows subsequent REGISTERs to expect not to be challenged.
