### PR TITLE
Log endpoint numbers

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -123,6 +123,7 @@ class TestDefinition
     @endpoints.each do |e|
       e.cleanup
     end
+    @endpoints = []
   end
 
   # @@TODO - Don't pass transport in once UDP authentication is fixed


### PR DESCRIPTION
Simple change to log out all the used phone numbers used in each test.  This makes finding the related diagnostics in tcpdump/logs/SAS much easier, especially for passing tests.
