### PR TITLE
Extend timeout for the real call test to give the user time to pick up the phone

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -280,7 +280,7 @@ class LiveTestDefinition < PSTNTestDefinition
   def run(*args)
     clear_diags
     if ENV['LIVENUMBER']
-      # The live call take approximately 10 seconds to run so extend the timeout
+      # The live call takes approximately 10 seconds to run so extend the timeout
       # for this test.
       @timeout = 20
       super


### PR DESCRIPTION
The live call is 8 seconds long, once you add in setup time, routing and pick-up time, we're running very close to the 10 seconds timeout.

Add a modify-able timeout parameter to tests (defaulting to 10s) and make it longer for the real call test.
