### PR TITLE
Expect to skip auth challenges and use UUIDs for instances

### DIFF
--- a/lib/live-test.rb
+++ b/lib/live-test.rb
@@ -68,7 +68,6 @@ def destroy_leaked_numbers(domain)
   # Destroy default SIP URIs last
   default_numbers = j["numbers"].select { |n| is_default_public_id? n }
   ordered_numbers = (j["numbers"] - default_numbers) + default_numbers
-  puts ordered_numbers
   ordered_numbers.each do |n|
     begin
       puts "Deleting leaked number: #{n["sip_uri"]}"

--- a/lib/tests/basic-register.rb
+++ b/lib/tests/basic-register.rb
@@ -45,7 +45,7 @@ TestDefinition.new("Multiple Identities") do |t|
   ep2 = t.add_public_identity(ep1)
   t.set_scenario(
     ep1.register +
-    ep2.register +
+    ep2.register(false) +
     ep1.unregister +
     ep2.unregister
   )

--- a/templates/REGISTER.erb
+++ b/templates/REGISTER.erb
@@ -12,9 +12,9 @@
       User-Agent: Clearwater Live Test Agent
       Supported: outbound, path
       <% if defined?(nat_contact_header) and nat_contact_header %>
-      Contact: <sip:<%= sender.username %>@[$nat_ip_addr]:[$nat_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:00000000-0000-0000-0000-00001>"
+      Contact: <sip:<%= sender.username %>@[$nat_ip_addr]:[$nat_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:<%= sender.instance_id %>>"
       <% end %>
-      Contact: <sip:<%= sender.username %>@[local_ip]:[local_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:00000000-0000-0000-0000-00001>"
+      Contact: <sip:<%= sender.username %>@[local_ip]:[local_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:<%= sender.instance_id %>>"
       <% if defined?(expires) %>
       Expires: <%= expires %>
       <% else %>


### PR DESCRIPTION
This brings the live test framework in line with the multiple identity authorization changes.  All `sipp-endpoint`s now have instance UUIDs that are included in REGISTER requests and I've re-instated the ability to expect not to be challenged on a register.
