### PR TITLE
Reviewer Andy: Enable live test suite to be used against a CW AIO node

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ There are various modifiers you can use to determine which subset of tests you w
  - `REPEATS=<number>` - to allow the suite of tests to be run multiple times.
  - `TRANSPORT=<transports>` - Comma-separated transports to test with.  Allowed tranports are `TCP` and `UDP`.  If not specified, all tests will be run twice, for each transport type.
  - `PROXY=<host>` - to force the tests to run against a particular Bono instance.
+ - `ELLIS=<host>` - to override the default FQDN for Ellis.  Useful when running against an AIO node.
  - `HOSTNAME=<host>` - publicly accessible hostname of the machine running the tests, used for the dummy AS.
 
 For example, to run all the call barring tests (including the international number barring tests) on the test deployment, run:

--- a/lib/sipp-endpoint.rb
+++ b/lib/sipp-endpoint.rb
@@ -226,7 +226,11 @@ private
   end
     
   def ellis_url path
-    "http://ellis.#{@domain}/#{path}"
+    if ENV['ELLIS']
+      "http://#{ENV['ELLIS']}/#{path}"
+    else
+      "http://ellis.#{@domain}/#{path}"
+    end 
   end
 
   def account_username


### PR DESCRIPTION
Andy, please can you review.  These changes allow the live test framework to run against a CW-AIO node. The key change is to allow overriding of the Ellis FQDN (because we need it to be http://<PROXY>, not http://ellis.<DOMAIN>).
Tested by running the tests against an AIO, and also against dogfood for the non-AIO case.
