### PR TITLE
{Reviewer: Mike} Add SNMP=N option to disable SNMP checking

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -239,7 +239,7 @@ class TestDefinition
       sipp_scripts = create_sipp_scripts
       @sipp_pids = launch_sipp sipp_scripts
       retval = wait_for_sipp
-      verify_snmp_stats
+      verify_snmp_stats if ENV['SNMP'] != "N"
     ensure
       retval &= cleanup
       TestDefinition.unset_current_test


### PR DESCRIPTION
Mike,

Small update to the code reviewed yesterday - this lets you use "SNMP=N" to avoid doing the per-call SNMP test.

Rob
