### PR TITLE
Reviewer Mike - Perform NAT-aware REGISTER

### DIFF
--- a/lib/sipp-endpoint.rb
+++ b/lib/sipp-endpoint.rb
@@ -107,8 +107,15 @@ class SIPpEndpoint
     end
     register_flow << recv("200", save_nat_ip: true)
     register_flow << SIPpPhase.new("__label", self, label_value: label_id)
-#    register_flow << send("REGISTER", nat_contact_header: true)
-#    register_flow << recv("200")
+
+    # ReREGISTER with NAT address in the Contact header
+    label_id = TestDefinition.get_next_label_id
+    register_flow << send("REGISTER", nat_contact_header: true)
+    register_flow << recv("200", optional: true, next_label: label_id)
+    register_flow << recv("401", save_auth: true)
+    register_flow << send("REGISTER", nat_contact_header: true, auth_header: true)
+    register_flow << recv("200")
+    register_flow << SIPpPhase.new("__label", self, label_value: label_id)
     register_flow
   end
 

--- a/templates/REGISTER.erb
+++ b/templates/REGISTER.erb
@@ -13,13 +13,10 @@
       Supported: outbound, path
       <% if defined?(nat_contact_header) and nat_contact_header %>
       Contact: <sip:<%= sender.username %>@[$nat_ip_addr]:[$nat_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:<%= sender.instance_id %>>"
-      <% end %>
-      Contact: <sip:<%= sender.username %>@[local_ip]:[local_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:<%= sender.instance_id %>>"
-      <% if defined?(expires) %>
-      Expires: <%= expires %>
       <% else %>
-      Expires: 3600
+      Contact: <sip:<%= sender.username %>@[local_ip]:[local_port];transport=[transport];ob>;reg-id=1;+sip.instance="<urn:uuid:<%= sender.instance_id %>>"
       <% end %>
+      <% if defined?(expires) %>Expires: <%= expires %><% else %>Expires: 3600<% end %>
       <% if defined?(auth_header) and auth_header %>
       [authentication username=<%= sender.private_id %> password=<%= sender.password %>]
       <% end%>


### PR DESCRIPTION
Mike, I found this branch in my checkout while tidying up.  This is needed to run the live tests through a strict P-CSCF (that uses the Contact header to correlate registrations to calls).

I've run these against the dogfood system and all tests are passing.
