### PR TITLE
[Reviewer: Andy] Add 1s pause before registration to avoid race conditions with the dummy...

### DIFF
--- a/lib/tests/isc-interface.rb
+++ b/lib/tests/isc-interface.rb
@@ -51,11 +51,11 @@ ASTestDefinition.new("ISC Interface - Terminating") do |t|
       invite_data = incoming_call.recv_request("INVITE")
       incoming_call.send_response("100 Trying")
       incoming_call.send_response("200 OK")
-      
+
       # This is received from Bono, so our sending destination automatically switches
       ack_data = incoming_call.recv_request("ACK")
       fail "Expecting INVITE from Sprout and ACK from Bono!" unless invite_data['source'].sock != ack_data['source'].sock
-      
+
       bye_data = incoming_call.recv_request("BYE")
       fail "Expecting ACK and BYE to both come from Bono!" unless bye_data['source'].sock == ack_data['source'].sock
 
@@ -77,7 +77,7 @@ ASTestDefinition.new("ISC Interface - Terminating") do |t|
       sip_caller.send("BYE", target: sip_callee, in_dialog: true),
       sip_caller.recv("200"),
     ] +
-    sip_caller.unregister 
+    sip_caller.unregister
   )
 end
 
@@ -103,7 +103,7 @@ ASTestDefinition.new("ISC Interface - Terminating Failed") do |t|
       c.terminate
     end
   end
- 
+
   t.set_scenario(
     sip_caller.register +
     [
@@ -142,9 +142,10 @@ ASTestDefinition.new("ISC Interface - Third-party Registration") do |t|
   end
 
   t.set_scenario(
+    [SIPpPhase.new("pause", sip_caller, timeout: 1000)] +
     sip_caller.register +
     [SIPpPhase.new("pause", sip_caller, timeout: 1000)] +
-    sip_caller.unregister 
+    sip_caller.unregister
   )
 end
 
@@ -177,13 +178,14 @@ ASTestDefinition.new("ISC Interface - Third-party Registration - implicit regist
   end
 
   t.set_scenario(
+    [SIPpPhase.new("pause", sip_caller, timeout: 1000)] +
     sip_caller.register +
     [SIPpPhase.new("pause", sip_caller, timeout: 1000)] +
     sip_caller.unregister +
     [SIPpPhase.new("pause", sip_caller, timeout: 1000)] +
     ep2.register +
     [SIPpPhase.new("pause", ep2, timeout: 1000)] +
-    ep2.unregister 
+    ep2.unregister
   )
 end
 
@@ -196,7 +198,7 @@ ASTestDefinition.new("ISC Interface - Redirect") do |t|
   mock_as = t.add_mock_as(ENV['HOSTNAME'], 5070)
 
   sip_callee1.set_ifc server_name: "#{ENV['HOSTNAME']}:5070"
-  
+
   t.set_scenario(
     sip_caller.register +
     sip_callee1.register +
@@ -236,7 +238,7 @@ ASTestDefinition.new("ISC Interface - B2BUA") do |t|
   sip_callee = t.add_sip_endpoint
 
   sip_caller.set_ifc server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"
-  
+
   t.add_quaff_endpoint do
     c = TCPSIPConnection.new(5070)
     begin


### PR DESCRIPTION
... AS that receives the third-party register

Fixes a bug we saw in the live tests when cutting the release.
