### PR TITLE
Reviewer Rob - Report failures correctly

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -100,6 +100,8 @@ class TestDefinition
           print "#{test.name} (#{trans.to_s.upcase}) - "
           if test.run(deployment, trans)
             puts RedGreen::Color.green("Passed")
+          else
+            record_failure
           end
         rescue StandardError => e
           record_failure


### PR DESCRIPTION
The last pull request meant that quaff errors wouldn't cause the tests to fail.  The calls record_failure if the quaff cleanup reports the test failed.
