### PR TITLE
Reviewer Matt - Use the previous Via header when handling in-dialog requests

### DIFF
--- a/templates/200.erb
+++ b/templates/200.erb
@@ -1,11 +1,7 @@
   <send>
     <![CDATA[
       SIP/2.0 200 OK
-      <% if defined? (second_transaction) and second_transaction %>
-      [$second_via]
-      <% else %>
-      [$uas_via]
-      <% end %>
+      [last_Via]
       [last_Record-Route:]
       From: <sip:<%= target.username %>@<%= target.domain %>>;tag=[pid]SIPpTag00[call_number]1234
       To: <sip:<%= sender.username %>@<%= sender.domain %>>;tag=[pid]SIPpTag00[call_number]4321


### PR DESCRIPTION
We now use `[$uas_via]` in `200-SDP.erb` and `[last_Via]` in `200.erb`.  With this change, we'll use the correct Via headers in all cases.

Tested with the dogfood system.
