### PR TITLE
Reviewer Rob - Escape ID before using it as a regexp (since + is a special character)

### DIFF
--- a/lib/live-test.rb
+++ b/lib/live-test.rb
@@ -90,5 +90,5 @@ def destroy_leaked_numbers(domain)
 end
 
 def is_default_public_id? number
-  /#{number["private_id"]}/ =~ number["sip_uri"]
+  /#{Regexp.escape(number["private_id"])}/ =~ number["sip_uri"]
 end


### PR DESCRIPTION
[As title]

Tested while cutting Halo release.
