### PR TITLE
[Reviewer: Graeme] Use recv_any_of to fix up B2BUA and SUBSCRIBE/NOTIFY reliability issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
-    abnf-parsing (0.2.0)
+    abnf-parsing (0.2.2)
     coderay (1.0.9)
     erubis (2.7.0)
-    facter (2.0.1)
+    facter (2.1.0)
       CFPropertyList (~> 2.2.6)
     git (1.2.5)
     jeweler (1.8.4)
@@ -30,7 +30,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    quaff (0.5.4)
+    quaff (0.6.1)
       abnf-parsing (>= 0.2.0)
       facter (>= 1.7.3)
       milenage (>= 0.1.0)

--- a/lib/tests/isc-interface.rb
+++ b/lib/tests/isc-interface.rb
@@ -373,10 +373,12 @@ NotValidForUDPASTestDefinition.new("ISC Interface - B2BUA") do |t|
     outgoing_call.send_request("ACK")
 
     incoming_call.send_response("200", "OK")
-    incoming_call.recv_request("ACK")
+
+    # We expect an ACK and a BYE - protect against them being sent out-of-order
+    incoming_call.recv_any_of ["ACK", "BYE"]
+    incoming_call.recv_any_of ["ACK", "BYE"]
 
     # Get the BYE, OK it, and pass it back
-    incoming_call.recv_request("BYE")
     incoming_call.send_response("200", "OK")
 
     outgoing_call.new_transaction

--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -43,8 +43,11 @@ TestDefinition.new("SIP SUBSCRIBE-NOTIFY") do |t|
     call = ep1.outgoing_call(ep1.uri)
 
     call.send_request("SUBSCRIBE", "", {"Event" => "reg", "To" => %Q[<#{ep1.uri}>;tag=1231231231], "From" => %Q[<#{ep1.uri}>;tag=2342342342]})
-    call.recv_response("200")
-    call.recv_request("NOTIFY")
+
+    # 200 and NOTIFY can come in any order, so expect either of them, twice
+    call.recv_any_of [200, "NOTIFY"]
+    call.recv_any_of [200, "NOTIFY"]
+
     call.send_response("200", "OK")
 
     ep1.register # Re-registration
@@ -52,9 +55,12 @@ TestDefinition.new("SIP SUBSCRIBE-NOTIFY") do |t|
     call.recv_request("NOTIFY")
     call.send_response("200", "OK")
 
+    call.update_branch
     call.send_request("SUBSCRIBE", "", {"Event" => "reg", "To" => %Q[<#{ep1.uri}>;tag=1231231231], "From" => %Q[<#{ep1.uri}>;tag=2342342342], "Expires" => 0})
-    call.recv_response("200")
-    call.recv_request("NOTIFY")
+
+    call.recv_any_of [200, "NOTIFY"]
+    call.recv_any_of [200, "NOTIFY"]
+
     call.send_response("200", "OK")
 
     ep1.register # Re-registration


### PR DESCRIPTION
It's Christmas come early for you. Tested by running SUBSCRIBE/NOTIFY ten times (5 TCP, 5 UDP) and getting consistent successes.
