### PR TITLE
[Reviewer: Alex] Take Quaff 0.6.2 to lower CPU usage and add retransmission detection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    quaff (0.6.1)
+    quaff (0.6.2)
       abnf-parsing (>= 0.2.0)
       facter (>= 1.7.3)
       milenage (>= 0.1.0)


### PR DESCRIPTION
Tested by:
- Running the live tests and keeping an eye on CPU usage - no sudden jumps
- Adding a 1s sleep to the PRACK test, which is enough to force the INVITE to be retransmitted, and verifying that it doesn't fail
