### PR TITLE
[Reviewer: Graeme] Fix bug causing invalid IFCs

### DIFF
--- a/templates/ifcs.xml.erb
+++ b/templates/ifcs.xml.erb
@@ -11,17 +11,11 @@
         <Method><% ifc[:method] ||= "INVITE" %><%= ifc[:method] %></Method>
         <Extension></Extension>
       </SPT>
-      <SPT>
-        <ConditionNegated>0</ConditionNegated>
-        <Group>0</Group>
-        <SessionCase><% ifc[:session_case] ||= "*" %><%= ifc[:session_case] %></SessionCase>
-        <Extension></Extension>
-      </SPT>
-      <% if defined?(session_case) %>
+      <% unless ifc[:session_case].nil? %>
        <SPT>
         <ConditionNegated>0</ConditionNegated>
         <Group>0</Group>
-        <SessionCase><%= session_case %></SessionCase>
+        <SessionCase><%= ifc[:session_case] %></SessionCase>
         <Extension></Extension>
       </SPT>
       <% end %>


### PR DESCRIPTION
The ISC live tests were failing because they had "*" as their session case, which isn't valid. This restores the previous behaviour of omitting that part of the XML if there's no session case (and removes a duplicated block).
