### PR TITLE
Reviewer AMC: Preserve Supported header in send_request

### DIFF
--- a/lib/quaff-monkey-patches.rb
+++ b/lib/quaff-monkey-patches.rb
@@ -27,9 +27,9 @@ a=fmtp:101 0-11,16\r
 module Quaff
   class Call
     def send_request(method, body="", headers={})
-      if not headers.include?("Supported") || headers["Supported"] == ""
+      if not headers.include? "Supported" || headers["Supported"] == ""
         headers["Supported"] = "gruu"
-      else
+      elsif not headers["Supported"] =~ /gruu/i
         headers["Supported"] += ", gruu"
       end
       msg = build_message headers, body, :request, method


### PR DESCRIPTION
Don't just overwrite the Supported header in send_request with 'gruu', instead check whether or not a Supported header has already been set.

The PRACK live test through Perimeta was failing because the caller didn't specify that they supported 100rel.
