### PR TITLE
[Reviewer: Ellie] Live tests for tel: URIs and BGCF

### DIFF
--- a/BGCF_Testing.md
+++ b/BGCF_Testing.md
@@ -9,7 +9,7 @@ configuration needs to be done in advance.
 
 ## Overview ##
 
-The "Off-net" tests (in [off-net.rb](lib/tests/off-net.rb)) do the
+The "Off-net" tests (in [offnet.rb](lib/tests/offnet.rb)) do the
 following:
 
 * listen on port 5072

--- a/BGCF_Testing.md
+++ b/BGCF_Testing.md
@@ -1,0 +1,58 @@
+The live tests allow you to test BGCF routing function, although this
+relies on specific configuration on your deployment (whereas the other
+live tests should all run successfully against any Project Clearwater
+deployment, and can take care of the necessary configuration
+themselves.)
+
+This document explains how to run these tests against a BGCF, and what
+configuration needs to be done in advance.
+
+## Overview ##
+
+The "Off-net" tests (in [off-net.rb](lib/tests/off-net.rb)) do the
+following:
+
+* listen on port 5072
+* register a subscriber (as normal - i.e. one automatically
+  provisioned on Ellis)
+* send a request out from that subscriber to a user-provided number
+  (given through the OFF_NET_TEL command-line option)
+* checks that this request comes back in on port 5072
+
+This allows it to test any BGCF rule that routes back to port 5072 on
+your test machine. In other words, to use this test effectively, you
+should:
+
+* choose a number (e.g. 2011000001)
+* learn the IP address of your test machine (e.g. 10.0.0.1)
+* set up your Clearwater deployment's ENUM, BGCF and firewall settings
+  so that a call to the 2011000001 will be routed back to
+  `sip:10.0.0.1:5072;transport=tcp`
+* Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=2011000001`
+  to run the off-net calling tests against this number
+
+## Example: testing standard BGCF routing ##
+
+* Set the following route in bgcf.json:
+```
+                {   "name" : "Test 1",
+                    "domain" : "otherdomain",
+                    "route" : ["sip:10.0.0.1:5072;transport=tcp"]
+                }
+```
+* Set up the following ENUM entry:
+        `1.0.0.0.0.0.0.0.0.1.e164.arpa.	3600	IN	NAPTR	1 1 "u" "E2U+sip" "!(^.*$)!sip:\\1@otherdomain!"`
+*  Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=1000000001`
+
+## Example: testing NP ##
+
+* Set the following route in bgcf.json:
+```
+                {   "name" : "Test 2",
+                    "routing number" : "1234-567-890",
+                    "route" : ["sip:10.0.0.1:5072;transport=tcp"]
+                }
+```
+* Set up the following ENUM entry:
+        `1.0.0.0.0.0.0.0.0.2.e164.arpa.	3600	IN	NAPTR	1 1 "u" "E2U+pstn:tel" "!(^.*$)!tel:\\1;npdi;rn=1234567890!"`
+*  Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=2000000001`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    quaff (0.7.0)
+    quaff (0.7.2)
       abnf-parsing (>= 0.2.0)
       milenage (>= 0.1.0)
       system-getifaddrs (>= 0.2.1)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ There are various modifiers you can use to determine which subset of tests you w
  - `EXCLUDE_TESTS="test1 (TCP),test2 (UDP)"` - a comma-separated list of tests to ignore. Useful for working around known bugs with tests in particular environments (e.g. skipping the B2BUA test in cases where the EC2 security group settings won't allow it)
  - `ELLIS_USER=<email>` - to override the default email used for Ellis (live.tests@example.com). Useful to allow multiple live test instances to run simultaneously without deleting each other's lines.
  - `SNMP=Y` - to verify the SNMP statistics produced in the test run.
+ - `OFF_NET_TEL=<number>` - an off-net number that should be routed back to this machine, for testing BGCF functionality. See [the BGCF Testing doc](BGCF_Testing.md) for more detail.
 
 For example, to run all the call barring tests (including the international number barring tests) on the test deployment, run:
 
@@ -114,6 +115,7 @@ There are different `skip` functions that can be included in a test. These contr
  - `skip_unless_<application server>`: Application Server test, requires that a hostname for the particular server is passed to rake as (for example) `GEMINI=...`.
  - `skip_if_udp`: Used to mark a test that's only valid when using TCP
  - `skip_unless_ellis_api_key`: Test that requires the Ellis API key, for example a test that creates specific endpoints
+ - `skip_unless_offnet_tel`: Test that requires an off-net number (specified by `OFF_NET_TEL`) to be routed back to this machine.
  - `skip`: Used to mark out currently broken tests, tests should not be left in this state for longer than necessary.
 
 

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -284,6 +284,11 @@ class TestDefinition
     raise SkipThisTest.new "No hostname given", "Call with HOSTNAME=<publicly accessible hostname/IP of this machine>" unless ENV['HOSTNAME']
   end
 
+  def skip_unless_offnet_tel
+    raise SkipThisTest.new "No off-net number given",
+                           "Call with OFF_NET_TEL=<a number set up in ENUM/BGCF to route to port 5072 on this machine>" unless ENV['OFF_NET_TEL']
+  end
+
   def skip_unless_ellis_api_key
     raise SkipThisTest.new "No Ellis API key given", "Call with ELLIS_API_KEY=<key>" unless ENV['ELLIS_API_KEY']
   end

--- a/lib/tests/basic-call.rb
+++ b/lib/tests/basic-call.rb
@@ -32,6 +32,11 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+def sip_to_tel(uri)
+  uri =~ /sip:(\d+)@.+/
+  "tel:#{$1}"
+end
+
 TestDefinition.new("Basic Call - Mainline") do |t|
   caller = t.add_endpoint
   callee = t.add_endpoint
@@ -76,6 +81,42 @@ TestDefinition.new("Basic Call - Mainline") do |t|
     call2.recv_request("ACK")
 
     call2.recv_request("BYE")
+    call2.send_response("200", "OK")
+    call2.end_call
+  end
+
+  t.add_quaff_cleanup do
+    caller.unregister
+    callee.unregister
+  end
+
+end
+
+TestDefinition.new("Basic Call - Tel URIs") do |t|
+  caller = t.add_endpoint
+  callee = t.add_endpoint
+
+  ringing_barrier = Barrier.new(2)
+
+  t.add_quaff_setup do
+    caller.register
+    callee.register
+  end
+
+  t.add_quaff_scenario do
+    tel = sip_to_tel(callee.uri)
+    call = caller.outgoing_call(tel)
+
+    call.send_request("MESSAGE", "hello world\r\n",
+                      {"Content-Type" => "text/plain"})
+    call.recv_response("200")
+    call.end_call
+  end
+
+  t.add_quaff_scenario do
+    call2 = callee.incoming_call
+
+    call2.recv_request("MESSAGE")
     call2.send_response("200", "OK")
     call2.end_call
   end

--- a/lib/tests/basic-call.rb
+++ b/lib/tests/basic-call.rb
@@ -32,6 +32,9 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+# Converts a URI like sip:1234@example.com to tel:1234. Doesn't
+# support parameters or non-numeric characters (e.g.
+# "sip:+1234;npdi@example.com" won't work).
 def sip_to_tel(uri)
   uri =~ /sip:(\d+)@.+/
   "tel:#{$1}"
@@ -104,6 +107,11 @@ TestDefinition.new("Basic Call - Tel URIs") do |t|
   end
 
   t.add_quaff_scenario do
+
+    # This tests that for a subscriber like sip:1234@example.com, a
+    # call to tel:1234 also reaches them. If this assumption is not
+    # true (e.g. due to unusual ENUM rewriting), this test will fail.
+    
     tel = sip_to_tel(callee.uri)
     call = caller.outgoing_call(tel)
 

--- a/lib/tests/offnet.rb
+++ b/lib/tests/offnet.rb
@@ -1,3 +1,38 @@
+# @file offnet.rb
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+
 TestDefinition.new("Off-net calls - tel: URI") do |t|
   t.skip_unless_offnet_tel
 

--- a/lib/tests/offnet.rb
+++ b/lib/tests/offnet.rb
@@ -1,0 +1,68 @@
+TestDefinition.new("Off-net calls - tel: URI") do |t|
+  t.skip_unless_offnet_tel
+
+  caller = t.add_endpoint
+  as = t.add_as 5072
+
+
+  t.add_quaff_setup do
+    caller.register
+  end
+
+  t.add_quaff_scenario do
+    call = caller.outgoing_call("tel:#{ENV['OFF_NET_TEL']}")
+
+    call.send_request("MESSAGE", "hello world\r\n",
+                      {"Content-Type" => "text/plain"})
+    call.recv_response("200")
+    call.end_call
+  end
+
+  t.add_quaff_scenario do
+    call2 = as.incoming_call
+
+    call2.recv_request("MESSAGE")
+    call2.send_response("200", "OK")
+    call2.end_call
+  end
+
+  t.add_quaff_cleanup do
+    caller.unregister
+  end
+
+end
+
+TestDefinition.new("Off-net calls - sip: URI") do |t|
+  t.skip_unless_offnet_tel
+
+  caller = t.add_endpoint
+  as = t.add_as 5072
+
+
+  t.add_quaff_setup do
+    caller.register
+  end
+
+  t.add_quaff_scenario do
+    call = caller.outgoing_call("sip:#{ENV['OFF_NET_TEL']}@#{t.deployment};user=phone")
+
+    call.send_request("MESSAGE", "hello world\r\n",
+                      {"Content-Type" => "text/plain"})
+    call.recv_response("200")
+    call.end_call
+  end
+
+  t.add_quaff_scenario do
+    call2 = as.incoming_call
+
+    call2.recv_request("MESSAGE")
+    call2.send_response("200", "OK")
+    call2.end_call
+  end
+
+  t.add_quaff_cleanup do
+    caller.unregister
+  end
+
+end
+


### PR DESCRIPTION
This adds:
* a test where I ring tel:1234 and check that it routes to sip:1234@domain. This is pretty basic function and should work everywhere.
* a test where I ring a user-defined number and check that it routes back to me on port 5072.

The latter is a generically useful test for checking some BGCF configuration. For example, to test basic BGCF routing (assuming I'm running the tests from 10.0.0.1), I'd:

* Set the following route in bgcf.json:
```
                {   "name" : "Test 1",
                    "domain" : "otherdomain",
                    "route" : ["sip:10.0.0.1:5072;transport=tcp"]
                }
```
* Set up the following ENUM entry:
        `1.0.0.0.0.0.0.0.0.1.e164.arpa.	3600	IN	NAPTR	1 1 "u" "E2U+sip" "!(^.*$)!sip:\\1@otherdomain!"`
*  Run `rake test[deployment] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=1000000001`

To test NP, I'd:

* Set the following route in bgcf.json:
```
                {   "name" : "Test 2",
                    "routing number" : "1234-567-890",
                    "route" : ["sip:10.0.0.1:5072;transport=tcp"]
                }
```
* Set up the following ENUM entry:
        `1.0.0.0.0.0.0.0.0.2.e164.arpa.	3600	IN	NAPTR	1 1 "u" "E2U+pstn:tel" "!(^.*$)!tel:\\1;npdi;rn=1234567890!"`
*  Run `rake test[deployment] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=2000000001`

Having the number be user-provided means that you can test several different sorts of off-net routing. (I'll document this in a Markdown file, roughly along the lines of what I've said above.)
