### PR TITLE
[Reviewer: AMC] Quaff 0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    quaff (0.8.0pre2)
+    quaff (0.8.0pre3)
       abnf-parsing (>= 0.2.0)
       milenage (>= 0.1.0)
       system-getifaddrs (>= 0.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    quaff (0.7.0)
+    quaff (0.8.0pre2)
       abnf-parsing (>= 0.2.0)
       milenage (>= 0.1.0)
       system-getifaddrs (>= 0.2.1)

--- a/lib/tests/basic-register.rb
+++ b/lib/tests/basic-register.rb
@@ -37,11 +37,11 @@ TestDefinition.new("Basic Registration") do |t|
 
   t.add_quaff_scenario do
     call = caller.outgoing_call(caller.uri)
-    call.send_request("REGISTER", "", { "Expires" => "3600", "Authorization" => %Q!Digest username="#{caller.private_id}"! })
+    call.send_request("REGISTER", headers: { "Expires" => "3600", "Authorization" => %Q!Digest username="#{caller.private_id}"! })
     response_data = call.recv_response("401")
+
     auth_hdr = Quaff::Auth.gen_auth_header response_data.header("WWW-Authenticate"), caller.private_id, caller.password, "REGISTER", caller.uri
-    call.update_branch
-    call.send_request("REGISTER", "", {"Authorization" => auth_hdr, "Expires" => "3600"})
+    call.send_request("REGISTER", headers: {"Authorization" => auth_hdr, "Expires" => "3600"})
     response_data = call.recv_response("200")
   end
 
@@ -57,19 +57,19 @@ TestDefinition.new("Multiple Identities") do |t|
 
   t.add_quaff_scenario do
     call = ep1.outgoing_call(ep1.uri)
-    call.send_request("REGISTER", "", { "Expires" => "3600", "Authorization" => %Q[Digest username="#{ep1.private_id}"] })
+    call.send_request("REGISTER", headers: { "Expires" => "3600", "Authorization" => %Q[Digest username="#{ep1.private_id}"] })
     response_data = call.recv_response("401")
+
     auth_hdr = Quaff::Auth.gen_auth_header response_data.header("WWW-Authenticate"), ep1.private_id, ep1.password, "REGISTER", ep1.uri
-    call.new_transaction
-    call.send_request("REGISTER", "", {"Authorization" => auth_hdr, "Expires" => "3600"})
+    call.send_request("REGISTER", headers: {"Authorization" => auth_hdr, "Expires" => "3600"})
     ok = call.recv_response("200")
 
     call2 = ep2.outgoing_call(ep2.uri)
-    call2.send_request("REGISTER", "", { "Expires" => "3600", "Authorization" => %Q[Digest username="#{ep2.private_id}"] })
+    call2.send_request("REGISTER", headers: { "Expires" => "3600", "Authorization" => %Q[Digest username="#{ep2.private_id}"] })
     response_data = call2.recv_response("401")
+
     auth_hdr = Quaff::Auth.gen_auth_header response_data.header("WWW-Authenticate"), ep2.private_id, ep2.password, "REGISTER", ep1.uri
-    call2.new_transaction
-    call2.send_request("REGISTER", "", {"Authorization" => auth_hdr, "Expires" => "3600"})
+    call2.send_request("REGISTER", headers: {"Authorization" => auth_hdr, "Expires" => "3600"})
     ok2 = call2.recv_response("200")
 
     fail "200 OK for #{ep1.uri} does not include <#{ep1.uri}>" unless

--- a/lib/tests/call-barring.rb
+++ b/lib/tests/call-barring.rb
@@ -53,7 +53,7 @@ TestDefinition.new("Call Barring - Outbound Rejection") do |t|
     call.send_request("INVITE")
     call.recv_response("100")
     call.recv_response("603")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -87,13 +87,11 @@ TestDefinition.new("Call Barring - Allow non-international call") do |t|
     call.recv_response("180")
 
     # Save off Contact and routeset
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
     sleep 1
 
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -139,7 +137,7 @@ TestDefinition.new("Call Barring - Reject international call") do |t|
     call.send_request("INVITE")
     call.recv_response("100")
     call.recv_response("603")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -170,7 +168,7 @@ TestDefinition.new("Call Barring - Inbound Rejection") do |t|
     call.send_request("INVITE")
     call.recv_response("100")
     call.recv_response("603")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 

--- a/lib/tests/call-barring.rb
+++ b/lib/tests/call-barring.rb
@@ -65,9 +65,8 @@ end
 
 TestDefinition.new("Call Barring - Allow non-international call") do |t|
   t.skip_unless_mmtel
-  t.skip_unless_pstn
 
-  caller = t.add_pstn_endpoint
+  caller = t.add_endpoint
   callee = t.add_endpoint
   caller.set_simservs ocb: { active: true,
                                  rules: [ { conditions: ["international"],
@@ -119,9 +118,8 @@ end
 
 TestDefinition.new("Call Barring - Reject international call") do |t|
   t.skip_unless_mmtel
-  t.skip_unless_pstn
-
-  caller = t.add_pstn_endpoint
+  
+  caller = t.add_endpoint
   callee = t.add_fake_endpoint("011447854481549")
   caller.set_simservs ocb: { active: true,
                              rules: [ { conditions: ["international"],

--- a/lib/tests/call-diversion-as.rb
+++ b/lib/tests/call-diversion-as.rb
@@ -65,12 +65,10 @@ class CDivASTestDestination < TestDefinition
       call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
       ringing_barrier.wait
 
-      call.recv_response_and_create_dialog("200")
-      call.new_transaction
+      call.recv_response("200", dialog_creating: true)
       call.send_request("ACK")
       ack_barrier.wait
 
-      call.new_transaction
       call.send_request("BYE")
       call.recv_response("200")
       call.end_call
@@ -196,13 +194,11 @@ CDivASTestDestination.new("Call Diversion AS - No answer") do |t|
     # Call is diverted to callee2
     call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
     ringing_barrier_2.wait
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
     ack_barrier.wait
 
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call

--- a/lib/tests/call-diversion.rb
+++ b/lib/tests/call-diversion.rb
@@ -67,12 +67,10 @@ class CDivTD < TestDefinition
       call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
       ringing_barrier.wait
 
-      call.recv_response_and_create_dialog("200")
-      call.new_transaction
+      call.recv_response("200", dialog_creating: true)
       call.send_request("ACK")
       ack_barrier.wait
 
-      call.new_transaction
       call.send_request("BYE")
       call.recv_response("200")
       call.end_call
@@ -343,13 +341,11 @@ CDivTD.new("Call Diversion - No answer") do |t|
     # Call is diverted to callee2
     call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
     ringing_barrier_2.wait
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
     ack_barrier.wait
 
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -394,7 +390,7 @@ TestDefinition.new("Call Diversion - Bad target URI") do |t|
     call.send_request("INVITE")
     call.recv_response("100")
     call.recv_response("480")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 

--- a/lib/tests/call-waiting.rb
+++ b/lib/tests/call-waiting.rb
@@ -223,7 +223,7 @@ TestDefinition.new("Call Waiting - Cancelled") do |t|
     fail "Alert-Info was not passed through properly" unless ringing_resp.first_header('Alert-Info') == "<urn:alert:service:call-waiting>"
 
     # C cancels the call
-    call.send_request("CANCEL", same_tsx_as: ringing_resp, new_tsx: false)
+    call.send_request("CANCEL", new_tsx: false)
     call.recv_response("200")
 
     call.recv_response("487")

--- a/lib/tests/cancel.rb
+++ b/lib/tests/cancel.rb
@@ -46,16 +46,16 @@ TestDefinition.new("CANCEL - Mainline") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee.uri)
 
-    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.send_request("INVITE", body: "hello world\r\n", headers: {"Content-Type" => "text/plain"})
     call.recv_response("100")
     call.recv_response("180")
 
     # New transaction, but CANCELs share the original branch parameter
-    call.send_request("CANCEL")
+    call.send_request("CANCEL", new_tsx: false)
     call.recv_response("200")
 
     call.recv_response("487")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -68,10 +68,8 @@ TestDefinition.new("CANCEL - Mainline") do |t|
     call2.recv_request("CANCEL")
     call2.send_response("200", "OK")
 
-    # Use assoc_with_msg to make the CSeq of the 487 follow the INVITE, not the CANCEL
-    call2.assoc_with_msg(original_invite)
-
-    call2.send_response("487", "Cancelled")
+    # Make the CSeq of the 487 follow the INVITE, not the CANCEL
+    call2.send_response("487", "Cancelled", response_to: original_invite)
     call2.recv_request("ACK")
 
     call2.end_call

--- a/lib/tests/contact-filtering.rb
+++ b/lib/tests/contact-filtering.rb
@@ -46,8 +46,8 @@ TestDefinition.new("Filtering - Accept-Contact") do |t|
     call = caller.outgoing_call(callee.uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain", "Accept-Contact" => "*;+sip.instance=\"<urn:uuid:#{callee.instance_id}>\";explicit;require"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain", "Accept-Contact" => "*;+sip.instance=\"<urn:uuid:#{callee.instance_id}>\";explicit;require"})
     call.recv_response("200")
     call.end_call
   end
@@ -79,8 +79,8 @@ TestDefinition.new("Filtering - Accept-Contact no match") do |t|
     call = caller.outgoing_call(callee.uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain", "Accept-Contact" => "*;+sip.instance=\"<wrong>\";explicit;require"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain", "Accept-Contact" => "*;+sip.instance=\"<wrong>\";explicit;require"})
     call.recv_response("480")
     call.end_call
     fail unless callee.no_new_calls?
@@ -107,8 +107,8 @@ TestDefinition.new("Filtering - Accept-Contact negated match") do |t|
     call = caller.outgoing_call(callee.uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain", "Accept-Contact" => "*;+sip.test=\"!hello\";explicit;require"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain", "Accept-Contact" => "*;+sip.test=\"!hello\";explicit;require"})
     call.recv_response("200")
     call.end_call
   end
@@ -171,10 +171,10 @@ TestDefinition.new("Filtering - RFC3841 example") do |t|
     call = caller.outgoing_call(callee_binding1.uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain",
-                        "Accept-Contact" => ["*;audio;require", "*;video;explicit", '*;methods="BYE";class="business";q=1.0'],
-                      "Reject-Contact" => '*;actor="msg-taker";video'})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain",
+                                "Accept-Contact" => ["*;audio;require", "*;video;explicit", '*;methods="BYE";class="business";q=1.0'],
+                                "Reject-Contact" => '*;actor="msg-taker";video'})
     call.recv_response("200")
     call.end_call
 
@@ -224,8 +224,8 @@ TestDefinition.new("Filtering - Reject-Contact no match") do |t|
     call = caller.outgoing_call(callee.uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain", "Reject-Contact" => "*;+sip.instance=\"<wrong>\""})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain", "Reject-Contact" => "*;+sip.instance=\"<wrong>\""})
     call.recv_response("200")
     call.end_call
   end
@@ -257,9 +257,9 @@ TestDefinition.new("Filtering - Reject-Contact match") do |t|
     call = caller.outgoing_call(callee.uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain",
-                        "Reject-Contact" => "*;+sip.instance=\"<urn:uuid:#{callee.instance_id}>\""})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain",
+                                "Reject-Contact" => "*;+sip.instance=\"<urn:uuid:#{callee.instance_id}>\""})
     call.recv_response("480")
     call.end_call
     fail unless callee.no_new_calls?

--- a/lib/tests/gemini.rb
+++ b/lib/tests/gemini.rb
@@ -75,13 +75,11 @@ TestDefinition.new("Gemini - INVITE - VoIP device answers") do |t|
     call.recv_response("180")
     call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
     ringing_barrier.wait
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
     end_call_barrier.wait
 
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -167,13 +165,11 @@ TestDefinition.new("Gemini - INVITE - Mobile device answers") do |t|
     call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
 
     ringing_barrier.wait
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
     end_call_barrier.wait
 
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -192,8 +188,7 @@ TestDefinition.new("Gemini - INVITE - Mobile device answers") do |t|
     call_voip.recv_request("CANCEL")
     call_voip.send_response("200", "OK")
 
-    call_voip.assoc_with_msg(invite)
-    call_voip.send_response("487", "Request Terminated")
+    call_voip.send_response("487", "Request Terminated", response_to: invite)
     call_voip.recv_request("ACK")
 
     call_voip.end_call
@@ -260,13 +255,11 @@ TestDefinition.new("Gemini - INVITE - VoIP device rejects") do |t|
     ringing_barrier.wait
 
     # Mobile device accepts call
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
 
     end_call_barrier.wait
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -347,13 +340,11 @@ TestDefinition.new("Gemini - INVITE - Mobile device rejects") do |t|
     call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
     ringing_barrier.wait
 
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
 
     end_call_barrier.wait
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -442,13 +433,11 @@ TestDefinition.new("Gemini - INVITE - Mobile device rejects with a 480") do |t|
     ringing_barrier.wait
     call.recv_response("180") unless ENV['PROVISIONAL_RESPONSES_ABSORBED']
 
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
 
     end_call_barrier.wait
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -541,7 +530,7 @@ TestDefinition.new("Gemini - INVITE - Both reject, choose mobile response") do |
     ringing_barrier.wait
 
     call.recv_response("500")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -615,7 +604,7 @@ TestDefinition.new("Gemini - INVITE - Both reject, choose VoIP response") do |t|
     ringing_barrier.wait
 
     call.recv_response("487")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -684,13 +673,11 @@ TestDefinition.new("Gemini - INVITE - Successful call with GR") do |t|
 
     call.recv_response("100")
     call.recv_response("180")
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
 
     end_call_barrier.wait
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -750,7 +737,7 @@ TestDefinition.new("Gemini - INVITE - Failed call with GR") do |t|
     call.recv_response("100")
     call.recv_response("180")
     call.recv_response("486")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -801,17 +788,15 @@ TestDefinition.new("Gemini - INVITE - Successful call with Accept-Contact") do |
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_voip.uri)
 
-    call.send_request("INVITE", "", {"Accept-Contact" => "*;g.3gpp.ics"})
+    call.send_request("INVITE", headers: {"Accept-Contact" => "*;g.3gpp.ics"})
 
     call.recv_response("100")
     call.recv_response("180")
-    call.recv_response_and_create_dialog("200")
+    call.recv_response("200", dialog_creating: true)
 
-    call.new_transaction
     call.send_request("ACK")
 
     end_call_barrier.wait
-    call.new_transaction
     call.send_request("BYE")
     call.recv_response("200")
     call.end_call
@@ -865,11 +850,11 @@ TestDefinition.new("Gemini - INVITE - Failed call with Accept-Contact") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_voip.uri)
 
-    call.send_request("INVITE", "", {"Accept-Contact" => "*;g.3gpp.ics"})
+    call.send_request("INVITE", headers: {"Accept-Contact" => "*;g.3gpp.ics"})
     call.recv_response("100")
     call.recv_response("180")
     call.recv_response("486")
-    call.send_request("ACK")
+    call.send_request("ACK", new_tsx: false)
     call.end_call
   end
 
@@ -917,7 +902,7 @@ TestDefinition.new("Gemini - SUBSCRIBE - Mobile Notifies") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_voip.uri)
 
-    call.send_request("SUBSCRIBE", "", {"Event" => "arbitrary"})
+    call.send_request("SUBSCRIBE", headers: {"Event" => "arbitrary"})
 
     call.recv_200_and_notify
     call.send_response("200", "OK")
@@ -944,7 +929,6 @@ TestDefinition.new("Gemini - SUBSCRIBE - Mobile Notifies") do |t|
 
     call_mobile.send_response("200", "OK")
 
-    call_mobile.new_transaction
     call_mobile.send_request("NOTIFY")
     call_mobile.recv_response("200")
     call_mobile.end_call
@@ -979,7 +963,7 @@ TestDefinition.new("Gemini - SUBSCRIBE - Joint 408") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_voip.uri)
 
-    call.send_request("SUBSCRIBE", "", {"Event" => "arbitrary"})
+    call.send_request("SUBSCRIBE", headers: {"Event" => "arbitrary"})
     call.recv_response("408")
     call.end_call
   end

--- a/lib/tests/gruu.rb
+++ b/lib/tests/gruu.rb
@@ -142,8 +142,8 @@ TestDefinition.new("GRUU - Call - first endpoint GRUU as target") do |t|
     call = caller.outgoing_call(binding1.expected_pub_gruu)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("200")
     call.end_call
     fail "Call was incorrectly forked to both endpoints" unless binding2.no_new_calls?
@@ -178,8 +178,8 @@ TestDefinition.new("GRUU - Call - second endpoint GRUU as target") do |t|
     call = caller.outgoing_call(binding2.expected_pub_gruu)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("200")
     call.end_call
     fail "Call was incorrectly forked to both endpoints" unless binding1.no_new_calls?
@@ -214,8 +214,8 @@ TestDefinition.new("GRUU - Call - only GRUU as target") do |t|
     call = caller.outgoing_call(binding1.expected_pub_gruu)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("200")
     call.end_call
     fail "Call was incorrectly forked to both endpoints" unless binding2.no_new_calls?
@@ -250,8 +250,8 @@ TestDefinition.new("GRUU - Call - AoR as target") do |t|
     call = caller.outgoing_call(binding2.sip_uri)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("200")
     call.end_call
     fail "Call was not forked to both endpoints" if binding1.no_new_calls?
@@ -286,8 +286,8 @@ TestDefinition.new("GRUU - Call - unknown GRUU as target") do |t|
     call = caller.outgoing_call(binding2.sip_uri + ";gr=nonsense")
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("480")
     call.end_call
   end
@@ -314,8 +314,8 @@ TestDefinition.new("GRUU - Call - unknown GRUU as target - no GRUUs assigned") d
     call = caller.outgoing_call(binding2.sip_uri + ";gr=nonsense")
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("480")
     call.end_call
   end
@@ -343,9 +343,9 @@ TestDefinition.new("GRUU - Call - Reject-Contact interop") do |t|
     call = caller.outgoing_call(binding1.expected_pub_gruu)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain",
-                      "Reject-Contact" => "*;audio"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain",
+                                "Reject-Contact" => "*;audio"})
     call.recv_response("480")
     call.end_call
   end
@@ -374,9 +374,9 @@ TestDefinition.new("GRUU - Call - Accept-Contact interop") do |t|
     call = caller.outgoing_call(binding1.expected_pub_gruu)
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain",
-                        "Accept-Contact" => "*;audio"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain",
+                                "Accept-Contact" => "*;audio"})
     call.recv_response("200")
     call.end_call
     fail "Call was incorrectly forked to both endpoints" unless binding2.no_new_calls?
@@ -411,8 +411,8 @@ TestDefinition.new("GRUU - Call - AoR with other param as target") do |t|
     call = caller.outgoing_call(binding2.sip_uri + ";arbitrary-param=\"an;gr=y\"")
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("200")
     call.end_call
     fail "Call was not forked to both endpoints" if binding1.no_new_calls?
@@ -447,8 +447,8 @@ TestDefinition.new("GRUU - Call - GRUU with other param as target") do |t|
     call = caller.outgoing_call(binding2.expected_pub_gruu + ";meaningless-param")
 
     call.send_request("MESSAGE",
-                      "hello world\r\n",
-                      {"Content-Type" => "text/plain"})
+                      body: "hello world\r\n",
+                      headers: {"Content-Type" => "text/plain"})
     call.recv_response("200")
     call.end_call
     fail "Call was incorrectly forked to both endpoints" unless binding1.no_new_calls?

--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -55,7 +55,7 @@ TestDefinition.new("SUBSCRIBE - reg-event") do |t|
   t.add_quaff_scenario do
     call = ep1.outgoing_call(ep1.uri)
 
-    call.send_request("SUBSCRIBE", "", {"Event" => "reg"})
+    call.send_request("SUBSCRIBE", headers: {"Event" => "reg"})
 
     # 200 and NOTIFY can come in any order, so expect either of them, twice
     notify1 = call.recv_200_and_notify
@@ -67,8 +67,7 @@ TestDefinition.new("SUBSCRIBE - reg-event") do |t|
     notify2 = call.recv_request("NOTIFY")
     call.send_response("200", "OK")
 
-    call.update_branch
-    call.send_request("SUBSCRIBE", "", {"Event" => "reg", "From" => notify1.headers['To'], "To" => notify1.headers['From'], "Expires" => 0})
+    call.send_request("SUBSCRIBE", headers: {"Event" => "reg", "Expires" => 0})
 
     notify3 = call.recv_200_and_notify
 
@@ -99,7 +98,7 @@ TestDefinition.new("SUBSCRIBE - reg-event with a GRUU") do |t|
   t.add_quaff_scenario do
     call = ep1.outgoing_call(ep1.uri)
 
-    call.send_request("SUBSCRIBE", "", {"Event" => "reg"})
+    call.send_request("SUBSCRIBE", headers: {"Event" => "reg"})
 
     # 200 and NOTIFY can come in any order, so expect either of them, twice
     notify = call.recv_200_and_notify


### PR DESCRIPTION
API changes:
- Keyword arguments rather than positional ones - which should be clearer
- A new request starting a new transaction is now the default - you disable it by passing `new_tsx: false` rather than enable it by calling `call.new_transaction`

Behind-the-scenes changes:
- I've cut message size down (shorter tags, shorter User-Agent header, etc)
- I've improved retransmissions
- I've improved dialog handling (fixing a bug where To/From could sometimes be swapped)

I've also added an `ignore_responses` argument (so `call.recv_response("200", ignore_responses: [100, 180])` is valid), but not used it here.

Finally, while fixing tests up, I noticed that we don't actually need PSTN connectivity to check that international call barring works, so I've fixed that test up.
