### PR TITLE
Reviewer Matt - Sort tests by filename so basic tests run first

### DIFF
--- a/lib/live-test.rb
+++ b/lib/live-test.rb
@@ -43,7 +43,7 @@ require_relative 'ellis'
 
 def run_tests(domain, glob="*")
   # Load and run all the tests
-  Dir[File.join(File.dirname(__FILE__), "tests", "*.rb")].each { |f| require f }
+  Dir[File.join(File.dirname(__FILE__), "tests", "*.rb")].sort.each { |f| require f }
   TestDefinition.run_all(domain, Wildcard[glob, true])
 
   # Cleanup leaked numbers.  Ignore (but print, using the magic exception


### PR DESCRIPTION
Simply sort the test definition files by name.  This has the nice (but fluky) property of running the basic tests first so the user can bail out if they're broken (as other tests are going to fail too anyway).