### PR TITLE
[Reviewer: Ellie] Print out Ellis errors in more detail

### DIFF
--- a/lib/ellis.rb
+++ b/lib/ellis.rb
@@ -59,7 +59,13 @@ class EllisProvisionedLine
                                       url: ellis_url(domain, "accounts/#{EMAIL}/numbers"),
                                       cookies: cookie)
     rescue RestClient::Exception => e
-      puts "Listing existing numbers failed with HTTP code #{e.http_code}, body #{e.http_body}"
+      puts "Listing existing numbers failed with HTTP code #{e.http_code}"
+      begin
+        j = JSON.parse(e.http_body)
+        puts "Detailed error output: #{j['detail']}"
+      rescue
+        # Just ignore errors here
+      end
       return
     end
     j = JSON.parse(r)

--- a/lib/ellis.rb
+++ b/lib/ellis.rb
@@ -54,9 +54,14 @@ class EllisProvisionedLine
                         email: EMAIL,
                         password: "Please enter your details")
     cookie = r.cookies
-    r = RestClient::Request.execute(method: :get,
-                                    url: ellis_url(domain, "accounts/#{EMAIL}/numbers"),
-                                    cookies: cookie)
+    begin
+      r = RestClient::Request.execute(method: :get,
+                                      url: ellis_url(domain, "accounts/#{EMAIL}/numbers"),
+                                      cookies: cookie)
+    rescue RestClient::Exception => e
+      puts "Listing existing numbers failed with HTTP code #{e.http_code}, body #{e.http_body}"
+      return
+    end
     j = JSON.parse(r)
 
     # Destroy default SIP URIs last
@@ -198,10 +203,14 @@ private
 
     payload = { pstn: pstn }
     payload.merge!(private_id: private_id) unless private_id.nil?
-    r = RestClient::Request.execute(method: :post,
-                                    url: ellis_url("accounts/#{account_email}/numbers/"),
-                                    cookies: @@security_cookie,
-                                    payload: payload)
+    begin
+      r = RestClient::Request.execute(method: :post,
+                                      url: ellis_url("accounts/#{account_email}/numbers/"),
+                                      cookies: @@security_cookie,
+                                      payload: payload)
+    rescue RestClient::Exception => e
+      fail "Account creation failed with HTTP code #{e.http_code}, body #{e.http_body}"
+    end
     setup_vars_from_json JSON.parse(r.body)
   end
 
@@ -218,12 +227,16 @@ private
 
   def delete_number
     return if @sip_uri.nil?
-    RestClient::Request.execute(
-      method: :delete,
-      url: ellis_url("accounts/#{account_email}/numbers/#{CGI.escape(@sip_uri)}"),
-      cookies: @@security_cookie,
-    ) do |rsp, req, result, &blk|
-      puts "Leaked #{@sip_uri}, DELETE returned #{rsp.code}" if rsp.code != 200
+    begin
+      RestClient::Request.execute(
+        method: :delete,
+        url: ellis_url("accounts/#{account_email}/numbers/#{CGI.escape(@sip_uri)}"),
+        cookies: @@security_cookie,
+      ) do |rsp, req, result, &blk|
+        puts "Leaked #{@sip_uri}, DELETE returned #{rsp.code}" if rsp.code != 200
+      end
+    rescue RestClient::Exception => e
+      fail "Account deletion of #{@sip_uri} failed with HTTP code #{e.http_code}, body #{e.http_body}"
     end
   end
 


### PR DESCRIPTION
This just makes it easier to diagnose issues like https://github.com/Metaswitch/ellis/issues/174 and https://github.com/Metaswitch/ellis/issues/175, by catching the exceptions and printing out more HTTP-level detail.

Output looks like:
```
$ bundle exec rake test[cw-ngv.com] TESTS="Basic Call - Mainline"
Basic Call - Mainline (TCP) - (6505550024, 6505550050) Passed
Basic Call - Mainline (UDP) - (6505550051, 6505550097) Passed
Listing existing numbers failed with HTTP code 502, body {"status": 502, "message": "Bad Gateway", "reason": "Upstream request failed", "detail": {"Upstream error": "HTTP 404: Not Found"}, "error": true}
```