### PR TITLE
[Reviewer: Alex] Run the live tests under TCP by default

### DIFF
--- a/BGCF_Testing.md
+++ b/BGCF_Testing.md
@@ -28,7 +28,7 @@ should:
 * set up your Clearwater deployment's ENUM, BGCF and firewall settings
   so that a call to the 2011000001 will be routed back to
   `sip:10.0.0.1:5072;transport=tcp`
-* Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=2011000001`
+* Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" OFF_NET_TEL=2011000001`
   to run the off-net calling tests against this number
 
 ## Example: testing standard BGCF routing ##
@@ -42,7 +42,7 @@ should:
 ```
 * Set up the following ENUM entry:
         `1.0.0.0.0.0.0.0.0.1.e164.arpa.	3600	IN	NAPTR	1 1 "u" "E2U+sip" "!(^.*$)!sip:\\1@otherdomain!"`
-*  Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=1000000001`
+*  Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" OFF_NET_TEL=1000000001`
 
 ## Example: testing NP ##
 
@@ -55,4 +55,4 @@ should:
 ```
 * Set up the following ENUM entry:
         `1.0.0.0.0.0.0.0.0.2.e164.arpa.	3600	IN	NAPTR	1 1 "u" "E2U+pstn:tel" "!(^.*$)!tel:\\1;npdi;rn=1234567890!"`
-*  Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" TRANSPORT=TCP OFF_NET_TEL=2000000001`
+*  Run `rake test[<DEPLOYMENT>] TESTS="Off-net*" OFF_NET_TEL=2000000001`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There are various modifiers you can use to determine which subset of tests you w
  - `PSTN=true` - to run the PSTN-specific tests (your deployment must have PSTN numbers allocated).
  - `LIVENUMBER=<number>` - to allow running of tests that dial out to real devices (your deployment must have an IBCF node and a working PSTN) the live number given may be dialled as part of running the test and the test will expect it to be answered (so make it a real one!).
  - `REPEAT=<number>` - to allow the suite of tests to be run multiple times.
- - `TRANSPORT=<transports>` - Comma-separated transports to test with.  Allowed tranports are `TCP` and `UDP`.  If not specified, all tests will be run twice, for each transport type.
+ - `TRANSPORT=<transports>` - Comma-separated transports to test with. Allowed tranports are `TCP` and `UDP`. If not specified, the tests will be run using `TCP` only.
  - `PROXY=<host>` - to force the tests to run against a particular Bono instance. Useful when running against an AIO node, or when the Bono domain isn't DNS resolvable.
  - `ELLIS=<host>` - to override the default FQDN for Ellis.  Useful when running against an AIO node, or when the Ellis domain isn't DNS resolvable.
  - `HOSTNAME=<host>` - publicly accessible hostname of the machine running the tests, used for the dummy AS.

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -107,12 +107,12 @@ class TestDefinition
 
   def self.run_all(deployment, glob)
     ENV['REPEAT'] ||= "1"
-    ENV['TRANSPORT'] ||= "tcp,udp"
+    ENV['TRANSPORT'] ||= "tcp"
     repeat = ENV['REPEAT'].to_i
     req_transports = ENV['TRANSPORT'].downcase.split(',').map { |t| t.to_sym }
     transports = [:tcp, :udp].select { |t| req_transports.include? t }
 
-    unless req_transports == transports
+    unless req_transports.sort == transports.sort
       STDERR.puts "ERROR: Unsupported transports #{req_transports - transports} requested"
       exit 2
     end


### PR DESCRIPTION
This moves the live tests to run using TCP by default. 

Tested live