### PR TITLE
[Reviewer: Graeme] End of test report

### DIFF
--- a/lib/live-test.rb
+++ b/lib/live-test.rb
@@ -50,7 +50,12 @@ def run_tests(domain, glob="*")
   # variables) any exceptions.
   EllisProvisionedLine.destroy_leaked_numbers(domain) rescue puts $!, $@
 
-  exit (TestDefinition.failures == 0) ? 0 : 1
+  puts "#{TestDefinition.failures.length} failures out of #{TestDefinition.tests_run} tests run"
+  TestDefinition.failures.each do |f|
+    puts "    #{f}"
+  end
+  puts "#{TestDefinition.skipped} tests skipped"
+  exit (TestDefinition.failures.length == 0) ? 0 : 1
 end
 
 def is_default_public_id? number

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -90,7 +90,7 @@ class TestDefinition
   end
 
   def self.record_failure test_id
-    @@failures << test_id
+    @@failures << "#{test_id} at #{Time.new.inspect}"
   end
 
   def self.failures

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -75,7 +75,9 @@ class TestDefinition
 
   @@tests = []
   @@current_test = nil
-  @@failures = 0
+  @@failures = []
+  @@tests_run = 0
+  @@skipped = 0
 
 # Class methods
 
@@ -87,12 +89,20 @@ class TestDefinition
     @@tests
   end
 
-  def self.record_failure
-    @@failures += 1
+  def self.record_failure test_id
+    @@failures << test_id
   end
 
   def self.failures
     @@failures
+  end
+
+  def self.tests_run
+    @@tests_run
+  end
+
+  def self.skipped
+    @@skipped
   end
 
   def self.get_diags
@@ -127,6 +137,7 @@ class TestDefinition
       puts "Test iteration #{r + 1}" if repeat != 1
       tests_to_run.product(transports).collect do |test, trans|
         begin
+          @@tests_run += 1
           test_id = "#{test.name} (#{trans.to_s.upcase})"
           print "#{test_id} - "
           tests_to_exclude.each do |exclusion|
@@ -138,13 +149,17 @@ class TestDefinition
           if success == true
             puts RedGreen::Color.green("Passed")
           elsif success == false
-            record_failure
+            record_failure(test_id)
+          else
+            # Do nothing if success == nil - that means we skipped a test
+            @@skipped += 1
           end # Do nothing if success == nil - that means we skipped a test
         rescue SkipThisTest => e
           puts RedGreen::Color.yellow("Skipped") + " (#{e.why_skipped})"
           puts "   - #{e.how_to_enable}" if e.how_to_enable
+          @@skipped += 1
         rescue StandardError => e
-          record_failure
+          record_failure(test_id)
           puts RedGreen::Color.red("Failed")
           puts "  #{e.class} thrown:"
           puts "   - #{e}"


### PR DESCRIPTION
I've sometimes had a couple of problems when looking at the output of clearwater-live-test:

* when cutting the release, the tests usually scroll off the page and I have to scroll back up and hunt through to see if I can spot any failures
* when debugging tests, especially if I start some tests and come back to it later, I don't always know when the test failed and therefore when to search for diags

To improve this, I've made the test runner print out a summary:

```
2 failures out of 14 tests run
    Basic Call - Mainline (UDP) at 2016-07-23 11:26:37 +0000
    Basic Call - Mainline (UDP) at 2016-07-23 11:26:51 +0000
0 tests skipped
```