### PR TITLE
[Reviwer: Ellie] Add diags to help track down SUBSCRIBE/NOTIFY failure

### DIFF
--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -210,7 +210,10 @@ TestDefinition.new("SUBSCRIBE - Registration timeout") do |t|
     call.end_call
 
     # Validate NOTIFYs are correctly formed
-    fail "NOTIFY responses have invalid CSeq! (same or non-incrementing)" if notify1.header('CSeq') >= notify2.header('CSeq')
+    if notify1.header('CSeq') >= notify2.header('CSeq')
+      fail "NOTIFY responses have same or non-incrementing CSeq - \
+first one had '#{notify1.header('CSeq')}', second one had '#{notify2.header('CSeq')}'"
+    end
 
     validate_notify notify1.body
     validate_notify notify2.body

--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -115,7 +115,7 @@ TestDefinition.new("SUBSCRIBE - reg-event with a GRUU") do |t|
     end
 
     fail "Binding 1 has no pub-gruu node" unless (xmldoc.child.child.children[0].children[1].name == "pub-gruu")
-    fail "Binding 1 has an incorrect pub-gruu node" unless (xmldoc.child.child.children[0].children[1]['uri'] == ep1.expected_pub_gruu)
+    fail "Binding 1 has an incorrect pub-gruu node (expected #{ep1.expected_pub_gruu}):\n#{notify.body}" unless (xmldoc.child.child.children[0].children[1]['uri'] == ep1.expected_pub_gruu)
     validate_notify xmldoc.child.child.children[0].children[1].dup.to_s, "schemas/gruuinfo.xsd"
   end
 


### PR DESCRIPTION
As I think we've discussed before, this test fails unusually often (7 times out of 408 runs) so there might be a bug here. I've added extra diagnostics to help see what's going on.

I reversed the if test to force it to fail so I could see the diags:

```
SUBSCRIBE - Registration timeout (UDP) - (6515550001, 6515550018) Failed
Endpoint threw exception:
 - NOTIFY responses have same or non-incrementing CSeq - first one had '3 NOTIFY', second one had '4 NOTIFY'
   - /home/ubuntu/clearwater-live-test/lib/tests/subscribe.rb:215:in `block (2 levels) in <top (required)>'
```