### PR TITLE
Fix Bono SNMP OIDs in verify_snmp_stats

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -432,9 +432,9 @@ class TestDefinition
 
   def verify_snmp_stats
     latency_threshold = 250
-    average_oid = SNMP::ObjectId.new "1.2.826.0.1.1578918.9.2.2.1.2"
-    hwm_oid = SNMP::ObjectId.new "1.2.826.0.1.1578918.9.2.2.1.4"
-    lwm_oid = SNMP::ObjectId.new "1.2.826.0.1.1578918.9.2.2.1.5"
+    average_oid = SNMP::ObjectId.new "1.2.826.0.1.1578918.9.2.2.1.2.1"
+    hwm_oid = SNMP::ObjectId.new "1.2.826.0.1.1578918.9.2.2.1.4.1"
+    lwm_oid = SNMP::ObjectId.new "1.2.826.0.1.1578918.9.2.2.1.5.1"
     snmp_host = ENV['PROXY'] ? IPSocket.getaddress(ENV['PROXY']) : IPSocket.getaddress(@deployment)
     snmp_map = {}
     SNMP::Manager.open(:host => snmp_host, :community => "clearwater") do |manager|


### PR DESCRIPTION
I hope you're the right person for this Rob; if not, my apologies.

Change made to fix the SNMP test, in the verify_snmp_stats function in test-definition.rb.

The OIDs were missing a .1/.2/.3 on the end to specify time period (previous 5s, current 5s, previous 5m respectively), which might have been added to the SNMP stats for Bono after these tests were written. 

I am not too familiar with these tests and was unsure what time period would be appropriate; I have specified previous 5 seconds for now, but this would be easy to change. 

I have tested these against a Clearwater deployment. Previously, testing with the SNMP=Y argument resulted in the "No SNMP responses from Bono" message for every test. Now they run without this message and without raising any errors.