### PR TITLE
Reviewer RKD: More reliable checking of forking

### DIFF
--- a/lib/tests/contact-filtering.rb
+++ b/lib/tests/contact-filtering.rb
@@ -181,18 +181,18 @@ TestDefinition.new("Filtering - RFC3841 example") do |t|
   end
 
   t.add_quaff_scenario do
-    # Wait long enough to ensure the call is forked
-    sleep 0.3
-
     # Call should be forked to bindings 1, 4 and 5 simultaneously -
-    # answer it from 5 and check that 1 and 4 have a call come in
-    call2 = callee_binding5.incoming_call
+    # check that 1 and 4 have a call come in and then answer it from 5.
+    call2 = callee_binding1.incoming_call
     call2.recv_request("MESSAGE")
-    call2.send_response("200", "OK")
-    call2.end_call
 
-    fail "Call was not forked to binding 1" if callee_binding1.no_new_calls?
-    fail "Call was not forked to binding 4" if callee_binding4.no_new_calls?
+    call3 = callee_binding4.incoming_call
+    call3.recv_request("MESSAGE")
+
+    call4 = callee_binding5.incoming_call
+    call4.recv_request("MESSAGE")
+    call4.send_response("200", "OK")
+    call4.end_call
 
     # Expect binding 3 to be rejected because it matches the Reject-Contact
     fail "Call was forked to binding 3" unless callee_binding3.no_new_calls?


### PR DESCRIPTION
I ran this test 10 times plus on its own on my dev box and it failed every time. After my fix, I've run it 22 times and counting without it failing.

I haven't worked out *exactly* why the test was previous failing but this seems like a sensible fix. I assume that `recv_request` actually waits to receive the message, whereas the `no_new_calls` check obviously does not. Despite the sleep we still seemed to occasionally reach the `no_new_calls` check for binding 1 before the call arrived.

Fixes #128.