### PR TITLE
[Reviewer: Graeme] Fail test as soon as one thread throws an exception

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -379,32 +379,72 @@ class TestDefinition
       end
   end
 
+  def cull_thread t, timeout, print_failed
+    # Join the threads, this will do one of three things:
+    #  - If the thread has finished successfully, return the thread handle
+    #  - If the thread has finished abnormally, return the exception thrown,
+    #    and also print out the backtrace
+    #  - If the thread has not finished within the timeout, return nil
+    result_of_join = begin
+                       t.join(timeout)
+                     rescue StandardError => e
+                       e
+                     end
+
+    if result_of_join and (result_of_join != t)
+      puts RedGreen::Color.red("Failed") if print_failed
+
+      puts "Endpoint threw exception:"
+      puts " - #{e.message}"
+      e.backtrace.each { |b| puts "   - #{b}" }
+    end
+
+    return result_of_join
+  end
+
   def cleanup
     retval = true
-    @quaff_threads.each do |t|
-      # Join the threads, this will do one of three things:
-      #  - Return the thread handle, indicating complete success
-      #  - Return nil indicating that the 60 seconds passed
-      #  - Throw an exception caught in the thread
-      result_of_join = begin
-                         t.join(60)
-                       rescue StandardError => e
-                         e
-                       end
-      unless result_of_join == t
-        puts RedGreen::Color.red("Failed") if retval
 
-        if result_of_join.nil?
-          puts "Endpoint had outstanding work to do, current backtrace:"
-          t.backtrace.each { |b| puts "   - #{b}" }
-          t.kill
-        else
-          puts "Endpoint threw exception:"
-          puts " - #{e.message}"
-          e.backtrace.each { |b| puts "   - #{b}" }
+    # Poll the finished and non-finished threads one per second - this allows
+    # us to exit the first time a thread throws an exception.
+    (1..60).each do |second|
+      finished_threads = @quaff_threads.select { |t| t.stop? }
+      alive_threads = @quaff_threads.select { |t| t.alive? }
+
+      finished_threads.each do |t|
+        result_of_join = cull_thread(t, 0, retval)
+
+        if result_of_join and (result_of_join != t)
+          # If cull_thread doesn't return the thread handle, the thread has
+          # exited abnormally. We know the test has failed in this case, so
+          # stop the other threads now.
+          puts "Terminating other threads after failure"
+          alive_threads.each do |t|
+            t.kill
+            cull_thread(t, 60, false)
+          end
+
+          retval = false
+          break
         end
+      end
 
-        retval = false
+      all_threads_finished = @quaff_threads.select { |t| t.alive? }.empty?
+
+      # End even though 60 seconds haven't passed
+      break if all_threads_finished
+      
+      sleep 1
+    end
+
+    all_threads_finished = @quaff_threads.select { |t| t.alive? }.empty?
+
+    unless all_threads_finished
+      puts RedGreen::Color.red("Failed") if retval
+      @quaff_threads.select { |t| t.alive? }.each do |t|
+        puts "Endpoint had outstanding work to do, current backtrace:"
+        t.backtrace.each { |b| puts "   - #{b}" }
+        t.kill
       end
     end
 

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -419,7 +419,8 @@ class TestDefinition
           # exited abnormally. We know the test has failed in this case, so
           # stop the other threads now.
           puts "Terminating other threads after failure"
-          alive_threads.each do |t|
+          other_threads = @quaff_threads.reject { |other_thread| other_thread == t }
+          other_threads.each do |t|
             t.kill
             cull_thread(t, 60, false)
           end


### PR DESCRIPTION
Tested by making `Basic Call - Mainline` throw an exception as soon as it gets an INVITE:

```
$ time bundle exec rake test[rkd.cw-ngv.com] TESTS="Basic Call - *"                             
Basic Call - Mainline (TCP) - (4155550031, 4155550454) Failed
Endpoint threw exception:
 - RKD
   - /home/ubuntu/clearwater-live-test/lib/tests/basic-call.rb:83:in `block (2 levels) in <top (required)>'
Terminating other threads after failure
Basic Call - SDP (TCP) - (4155550809, 4155550603) Passed
Basic Call - Tel URIs (TCP) - (4155550980, 4155550173) Passed
Basic Call - Unknown number (TCP) - (4155550514, 4155550844) Passed
Basic Call - Rejected by remote endpoint (TCP) - (4155550784, 4155550467) Passed
Basic Call - Messages - Pager model (TCP) - (4155550857, 4155550635) Passed
Basic Call - Pracks (TCP) - (4155550886, 4155550316) Passed
1 failures out of 7 tests run
    Basic Call - Mainline (TCP) at 2016-10-10 19:46:07 +0000
0 tests skipped

real    0m31.404s
user    0m0.808s
sys     0m0.064s
```

@jack-atack - this is the feature you were asking me about last week.