### PR TITLE
[Reviewer: Graeme] Cope with expires=2 instead of expires=3 in timing windows

### DIFF
--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -156,8 +156,9 @@ TestDefinition.new("SUBSCRIBE - Subscription timeout") do |t|
     validate_notify notify1.body
     validate_notify notify2.body
 
-    # Validate that the first NOTIFY was sent as active with the correct expiry
-    fail "Subscription-State header not indicating active; expiry=x" if notify1.header('Subscription-State') != "active;expires=3"
+    # Validate that the first NOTIFY was sent as active with the correct expiry.
+    # Allow "expires=2" or "expires=1" to cope with timing windows.
+    fail "Subscription-State header not indicating active; expiry=x" unless /active;expires=(1|2|3)/.match(notify1.header('Subscription-State'))
  
     # Validate that the final NOTIFY was sent due to subscription expiry
     fail "Final Subscription-State header not set to terminated" if notify2.header('Subscription-State') != "terminated;reason=timeout"

--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -158,7 +158,7 @@ TestDefinition.new("SUBSCRIBE - Subscription timeout") do |t|
 
     # Validate that the first NOTIFY was sent as active with the correct expiry.
     # Allow "expires=2" or "expires=1" to cope with timing windows.
-    fail "Subscription-State header not indicating active; expiry=x" unless /active;expires=(1|2|3)/.match(notify1.header('Subscription-State'))
+    fail "Subscription-State header not indicating active; expiry=x" unless /active;expires=(2|3)/.match(notify1.header('Subscription-State'))
  
     # Validate that the final NOTIFY was sent due to subscription expiry
     fail "Final Subscription-State header not set to terminated" if notify2.header('Subscription-State') != "terminated;reason=timeout"


### PR DESCRIPTION
I saw a test failure where:

* I ran this test
* Sprout received the SUBSCRIBE at 16:51:47.998 with expiry=3
* Sprout sent the NOTIFY at 16:51:48.005 (a new second), so it had expiry=2

This seems reasonable so I've updated the test to cope with that. (I've also allowed expires=1 just in case.)

Tested in `irb`:

```
2.3.0 :017 > /active;expires=(1|2|3)/.match("active;expires=3")
 => #<MatchData "active;expires=3" 1:"3">
2.3.0 :018 > /active;expires=(1|2|3)/.match("active;expires=2")
 => #<MatchData "active;expires=2" 1:"2">
2.3.0 :020 > /active;expires=(1|2|3)/.match("timeout")
 => nil
```