### PR TITLE
[Reviewer: RKD] Store the routeset from the 200 OK not the NOTIFY

### DIFF
--- a/lib/quaff-monkey-patches.rb
+++ b/lib/quaff-monkey-patches.rb
@@ -49,6 +49,7 @@ module Quaff
     end
 
     def recv_200_and_notify
+      # Store the routeset from the 200 OK, not the NOTIFY
       resp1 = recv_any_of [[200, true], ["NOTIFY", false]]
       resp2 = recv_any_of [[200, true], ["NOTIFY", false]]
 

--- a/lib/quaff-monkey-patches.rb
+++ b/lib/quaff-monkey-patches.rb
@@ -49,8 +49,8 @@ module Quaff
     end
 
     def recv_200_and_notify
-      resp1 = recv_any_of [200, "NOTIFY"]
-      resp2 = recv_any_of [200, "NOTIFY"]
+      resp1 = recv_any_of [[200, true], ["NOTIFY", false]]
+      resp2 = recv_any_of [[200, true], ["NOTIFY", false]]
 
       notify = resp1.method ? resp1 : resp2
       return notify


### PR DESCRIPTION
Store of the routeset from the 200 OK so that we put the right routeset on when sending in-dialog requests.

Tested live.