### PR TITLE
[Reviewer: AME2] Catch exceptions in quaff_cleanup_blk

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -454,7 +454,11 @@ class TestDefinition
     end
 
     if @quaff_cleanup_blk
-      @quaff_cleanup_blk.call
+      begin
+        @quaff_cleanup_blk.call
+      rescue => exception
+        puts "WARNING: Exception in quaff_cleanup_blk:\n - #{exception}"
+      end
     end
 
     on_failure unless retval


### PR DESCRIPTION
~@rkd-msw, if you're unable to review, please pass to the appropriate person.~ Just noticed that Rob is on holiday for a week - resassigning. @AME2, if you're not the right person, could you please point me in the right direction? Thanks

This adds a begin/rescue block around `@quaff_cleanup_blk.call` in the cleanup after every test. If an exception is hit, we print a warning to screen including the exception, and then continue the main cleanup.

This fixes a problem where hitting an exception in the test-defined cleanup block silently exits the cleanup process, leaving un-terminated endpoints.

This is easiest to hit if registration errors occur - typical cleanup blocks include unregistering callers, and if they don't get the expected 401|200, they throw an exception and callers/endpoints are not properly cleaned up. This leaves them active going into the next test, which causes issues - most notably "Address already in use" errors if new endpoints are set up on the same ports.