### PR TITLE
Let tests run from bundled environment

### DIFF
--- a/lib/live-test.rb
+++ b/lib/live-test.rb
@@ -34,6 +34,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+require 'bundler/setup'
 require 'rubygems'
 require 'rest-client'
 require 'joker'


### PR DESCRIPTION
If you try to use bundler to package up and then install the live test dependencies locally, then the tests fail.  This is fixed by requiring `bunder/setup` at the start of the tests.

Applying upstream from private repository.