### PR TITLE
[Reviewer: RKD] Add infra to retry test on failure

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -196,6 +196,7 @@ class TestDefinition
     @blk = blk
     @current_label_id = 0
     @timeout = 10
+    @repeat_on_failure = 0
   end
 
   # Methods for defining Quaff endpoints
@@ -284,9 +285,21 @@ class TestDefinition
       verify_snmp_bono_latency if ENV['BONO_SNMP'] == "Y"
     ensure
       retval &= cleanup
+
+      # If the test failed and we have retries set, recursively call run
+      if !retval and @repeat_on_failure > 0
+        @repeat_on_failure -= 1
+        puts "WARNING - Test failed iteration, retrying"
+        retval = self.run(deployment, transport, iteration)
+      end
+
       TestDefinition.unset_current_test
     end
     return retval
+  end
+
+  def set_repeat_on_failure(count)
+    @repeat_on_failure = count
   end
 
   def skip

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -69,7 +69,7 @@ class SkipThisTest < StandardError
 end
 
 class TestDefinition
-  attr_accessor :name, :current_label_id
+  attr_accessor :name, :current_label_id, :num_lives
   attr_reader :deployment
   attr_writer :timeout
 
@@ -196,7 +196,7 @@ class TestDefinition
     @blk = blk
     @current_label_id = 0
     @timeout = 10
-    @repeat_on_failure = 0
+    @num_lives = 0
   end
 
   # Methods for defining Quaff endpoints
@@ -287,8 +287,8 @@ class TestDefinition
       retval &= cleanup
 
       # If the test failed and we have retries set, recursively call run
-      if !retval and @repeat_on_failure > 0
-        @repeat_on_failure -= 1
+      if !retval and @num_lives > 0
+        @num_lives -= 1
         puts "WARNING - Test failed iteration, retrying"
         retval = self.run(deployment, transport, iteration)
       end
@@ -296,10 +296,6 @@ class TestDefinition
       TestDefinition.unset_current_test
     end
     return retval
-  end
-
-  def set_repeat_on_failure(count)
-    @repeat_on_failure = count
   end
 
   def skip


### PR DESCRIPTION
For unreliable tests that still offer a useful regression check. By setting `repeat_on_failure` to x, the test must fail (x+1) times in a row to be logged as an overall failure. 

This is done by a recursive call to `run` if the return value of the first run is false, and if `repeat_on_failure` is above 0. Before each recursive call, we subtract 1 from `repeat_on_failure`. This will repeat on any failure in the `begin/ensure` block in `run`.

Note that the red `Failed` text will still appear next to each failed iteration, but the test will not be logged as an overall failure unless all iterations fail. Example output:

```
Unreliable Test (TCP) (iter 77) - (3335550272) Failed
Endpoint threw exception:
 - Expected 200, got 400 (call ID 16553b4726407a8f8559da0a2acf92dc)
   <exception backtrace>
Terminating other threads after failure
WARNING - Test failed iteration, retrying
(3335550862) Passed

```