### PR TITLE
[Reviewer: RKD] Fix infra to retry test on failure

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -265,7 +265,7 @@ class TestDefinition
       # If the test failed and we have retries set, recursively call run
       if !retval and @num_lives > @lives_used
         @lives_used += 1
-        puts "WARNING - Test failed iteration #{@lives_used}, retrying"
+        print "WARNING - Test failed iteration #{@lives_used}, retrying "
         retval = self.run(deployment, transport, iteration)
       end
 

--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -172,6 +172,7 @@ class TestDefinition
     @current_label_id = 0
     @timeout = 10
     @num_lives = 0
+    @lives_used = 0
   end
 
   # Methods for defining Quaff endpoints
@@ -262,9 +263,9 @@ class TestDefinition
       retval &= cleanup
 
       # If the test failed and we have retries set, recursively call run
-      if !retval and @num_lives > 0
-        @num_lives -= 1
-        puts "WARNING - Test failed iteration, retrying"
+      if !retval and @num_lives > @lives_used
+        @lives_used += 1
+        puts "WARNING - Test failed iteration #{@lives_used}, retrying"
         retval = self.run(deployment, transport, iteration)
       end
 


### PR DESCRIPTION
Fixes an oversight in #151.

I overlooked the fact that the entire test block of code is called again on recursively calling `run` - not just the setup, scenario and cleanup blocks. This makes it unusable, as `num_lives` will get altered/reset each time the test is retried if it added lives - leading to infinite loops if the test fails every time.

As an easy fix, this adds a `lives_used` counter to each instance, which is incremented on retry. Provided num_lives is set to a single value in the test block (e.g. `num_lives = 2`), this now functions as intended.

(As a clarity change, I also swapped `puts` for `print` so that the new number and success/fail print is on the same line as the new iteration text, instead of below it.)

This has been properly tested this time, against a mock test that fails every time and sets `num_lives`.