### PR TITLE
[Reviewer: Alex] Don't assume the GRUU is the second element in the contact XML

### DIFF
--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -89,9 +89,11 @@ TestDefinition.new("SUBSCRIBE - reg-event with a GRUU") do |t|
       config.noblanks
     end
 
-    fail "Binding 1 has no pub-gruu node" unless (xmldoc.child.child.children[0].children[1].name == "pub-gruu")
-    fail "Binding 1 has an incorrect pub-gruu node (expected #{ep1.expected_pub_gruu}):\n#{notify.body}" unless (xmldoc.child.child.children[0].children[1]['uri'] == ep1.expected_pub_gruu)
-    validate_notify xmldoc.child.child.children[0].children[1].dup.to_s, "schemas/gruuinfo.xsd"
+    gruu = xmldoc.xpath("//xmlns:registration/xmlns:contact/gr:pub-gruu")
+
+    fail "Binding 1 does not have exactly 1 pub-gruu node in body:\nbody:#{notify.body}" unless (gruu.length == 1)
+    fail "Binding 1 has an incorrect pub-gruu node (expected #{ep1.expected_pub_gruu}):\n#{notify.body}" unless (gruu[0]['uri'] == ep1.expected_pub_gruu)
+    validate_notify gruu[0].dup.to_s, "schemas/gruuinfo.xsd"
   end
 
   t.add_quaff_cleanup do


### PR DESCRIPTION
Alex,

https://github.com/Metaswitch/sprout/pull/1878 changes how we build Sprout NOTIFYs.

The live test checks for this in a really brittle way when it comes to checking whether we have a GRUU. I've made it more resilient by using xpath, instead of just assuming the first element is a GRUU.

For reference the XML body we see now looks like the following:

```
<?xml version="1.0" encoding="UTF-8"?>
<reginfo xmlns="urn:ietf:params:xml:ns:reginfo" xmlns:gr="urn:ietf:params:xml:ns:gruuinfo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ere="urn:3gpp:ns:extRegExp:1.0" version="0" state="full">
 <registration aor="sip:6515550036@staging.cw-ngv.com" id="921170198579381024" state="active">
  <contact id="&lt;urn:uuid:7c9db050-5076-5432-8e7b-f7faf3a118b9&gt;" state="active" event="registered">
   <uri>sip:quaff@10.0.0.85:42042;transport=TCP;ob</uri>
   <unknown-param name="+sip.instance">&quot;&lt;urn:uuid:7c9db050-5076-5432-8e7b-f7faf3a118b9&gt;&quot;</unknown-param>
   <gr:pub-gruu uri="sip:6515550036@staging.cw-ngv.com;gr=urn:uuid:7c9db050-5076-5432-8e7b-f7faf3a118b9" />
  </contact>
 </registration>
</reginfo>
```

I've tested running the live tests against the staging system and they now pass.