### PR TITLE
[No reviewer] Fix syntax error in subscribe.rb

### DIFF
--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -253,7 +253,7 @@ TestDefinition.new("Multiple SUBSCRIBErs to one UE's reg-event") do |t|
     call2.send_request("SUBSCRIBE", "", {"Event" => "reg",
                                          "From" => notify2.headers['To'],
                                          "To" => notify2.headers['From'],
-                                         "Expires" => "0"}
+                                         "Expires" => "0"})
 
     notify5 = call2.recv_200_and_notify
     call2.send_response("200", "OK")


### PR DESCRIPTION
Pull request #146 was merged 7 hours ago, containing a syntax error. This completely prevents any of our live tests from running.

This fixes the syntax error, just to get the tests running again. I'm not sure if there are any other issues with the test - it fails, as expected because the Sprout build (containing the accompanying code change) failed, so the functionality is missing from my test deployment.