### PR TITLE
Docker build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "quaff"]
 	path = quaff
-	url = https://github.com/rkd91/quaff
+	url = git@github.com:Metaswitch/quaff.git
 [submodule "build-infra"]
 	path = build-infra
 	url = git@github.com:Metaswitch/clearwater-build-infra.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM ubuntu:14.04
 MAINTAINER maintainers@projectclearwater.org
 
 # Set up Ruby and the bundler
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install ruby1.9.1 ruby1.9.1-dev --yes
-#RUN source ~/.rvm/scripts/rvm && rvm autolibs enable rvm install 1.9.3 && rvm use 1.9.3
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install ruby1.9.1 ruby1.9.1-dev zlib1g-dev libzmq3-dev bundler git --yes
 
-RUN mkdir /home/live-test/clearwater-live-test
-COPY * > /home/live-test/clearwater-live-test/
+RUN mkdir -p /home/live-test/clearwater-live-test
+COPY ./ /home/live-test/clearwater-live-test/
 
 WORKDIR "/home/live-test/clearwater-live-test"
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 MAINTAINER maintainers@projectclearwater.org
 
-# Set up Ruby and the bundler
+# Install Ruby, bundler, and dependencies for the bundle install
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install ruby1.9.3 ruby1.9.1-dev zlib1g-dev libzmq3-dev bundler git --yes
 
 RUN mkdir -p /home/live-test/clearwater-live-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM ubuntu:14.04
 MAINTAINER maintainers@projectclearwater.org
 
 # Set up Ruby and the bundler
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install build-essential bundler git --yes
-RUN curl -L https://get.rvm.io | bash -s stable
-RUN source ~/.rvm/scripts/rvm && rvm autolibs enable rvm install 1.9.3 && rvm use 1.9.3
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install ruby1.9.1 ruby1.9.1-dev --yes
+#RUN source ~/.rvm/scripts/rvm && rvm autolibs enable rvm install 1.9.3 && rvm use 1.9.3
 
 RUN mkdir /home/live-test/clearwater-live-test
-COPY . > /home/live-test/clearwater-live-test/
+COPY * > /home/live-test/clearwater-live-test/
 
 WORKDIR "/home/live-test/clearwater-live-test"
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:14.04
+MAINTAINER maintainers@projectclearwater.org
+
+# Set up Ruby and the bundler
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install build-essential bundler git --yes
+RUN curl -L https://get.rvm.io | bash -s stable
+RUN source ~/.rvm/scripts/rvm && rvm autolibs enable rvm install 1.9.3 && rvm use 1.9.3
+
+RUN mkdir /home/live-test/clearwater-live-test
+COPY . > /home/live-test/clearwater-live-test/
+
+WORKDIR "/home/live-test/clearwater-live-test"
+RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER maintainers@projectclearwater.org
 
 # Set up Ruby and the bundler
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install ruby1.9.1 ruby1.9.1-dev zlib1g-dev libzmq3-dev bundler git --yes
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install ruby1.9.3 ruby1.9.1-dev zlib1g-dev libzmq3-dev bundler git --yes
 
 RUN mkdir -p /home/live-test/clearwater-live-test
 COPY ./ /home/live-test/clearwater-live-test/

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rest-client'
 gem 'joker', git: "https://github.com/bossmc/joker.git", branch: "use-extension-task"
 gem 'rake'
 gem 'snmp'
-gem 'quaff', git: "git@github.com:metaswitch/quaff.git", branch: "master"
+gem 'quaff', path: './quaff/'
 gem 'facter'
 gem 'nokogiri'
 gem 'barrier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: git@github.com:metaswitch/quaff.git
-  revision: f92372cac3e196085038d75e3ad35698ed3df503
-  branch: master
-  specs:
-    quaff (0.7.3)
-      abnf-parsing (>= 0.2.0)
-      milenage (>= 0.1.0)
-      system-getifaddrs (>= 0.2.1)
-
-GIT
   remote: https://github.com/bossmc/joker.git
   revision: 97ac2b5738b4964a446eec7939859b051d73d839
   branch: use-extension-task
@@ -17,6 +7,14 @@ GIT
       bacon (~> 1)
       rake (~> 10)
       rake-compiler (~> 0)
+
+PATH
+  remote: ./quaff/
+  specs:
+    quaff (0.7.3)
+      abnf-parsing (>= 0.2.0)
+      milenage (>= 0.1.0)
+      system-getifaddrs (>= 0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ The verification service produces SNMP alarms to indicate the status of the depl
 
 The verification service runs a very cut-down collection of tests, focussing on basic functionality tests. This means that, if the verification service reports that the deployment is OK, then subscribers are capable of registering and making calls.
 
+### Running in a docker container
+
+The test code and dependencies can be built into a docker image using the provided Dockerfile. Simply run `docker build -t clearwater/live-test .` from within the clearwater-live-test/ directory.
+This image can then be used to run the live tests, by running the above test command in the container. e.g. `docker run -it clearwater/live-test rake test[<deployment_name>] SIGNUP_CODE=<code>`
+
 ## Writing A New Test
 
 The test definitions are found in `lib/tests/*.rb` and should be pretty self-explanatory.  A basic test structure is as follows:


### PR DESCRIPTION
This adds in a Dockerfile, to build a live test image. 
So that there weren't issues in pulling the quaff code down, i've re-instated it as a submodule. I wonder if we should do similar for Joker, but at the moment it isn't causing issues, so not too fussed.

I've built this on my docker build machine, and i can successfully exec into the container, and run the mainline live test successfully, so i'm happy that's working. Running the  full set now, just to check fully.

Now that we have this, i'm not really  sure how valuable it is, which is a bit of a shame, but i don't see any harm in having it. Should probably work out what we're going to use if for though...