### PR TITLE
[No reviewer] Fix HOSTNAME clash that wrongly triggered tests

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -287,7 +287,7 @@ class TestDefinition
   end
 
   def skip_unless_hostname
-    raise SkipThisTest.new "No hostname given", "Call with HOSTNAME=<publicly accessible hostname/IP of this machine>" unless ENV['HOSTNAME']
+    raise SkipThisTest.new "No hostname given", "Call with HOST_NAME=<publicly accessible hostname/IP of this machine>" unless ENV['HOST_NAME']
   end
 
   def skip_unless_offnet_tel

--- a/lib/tests/isc-interface.rb
+++ b/lib/tests/isc-interface.rb
@@ -28,8 +28,8 @@ TestDefinition.new("ISC Interface - Terminating") do |t|
   end
 
   sdp = ""
-  caller.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"}]
-  callee.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"}]
+  caller.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP"}]
+  callee.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP"}]
 
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee.uri)
@@ -91,8 +91,8 @@ TestDefinition.new("ISC Interface - Terminating (UDP AS)") do |t|
   end
 
   sdp = ""
-  caller.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=UDP"}]
-  callee.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=UDP"}]
+  caller.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=UDP"}]
+  callee.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=UDP"}]
 
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee.uri)
@@ -147,8 +147,8 @@ TestDefinition.new("ISC Interface - Terminating Failed") do |t|
   end
 
   sdp = ""
-  caller.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"}]
-  callee.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"}]
+  caller.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP"}]
+  callee.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP"}]
 
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee.uri)
@@ -193,7 +193,7 @@ TestDefinition.new("ISC Interface - Third-party Registration") do |t|
   caller = t.add_endpoint
   as = t.add_as 5070
 
-  caller.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP", method: "REGISTER"}]
+  caller.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP", method: "REGISTER"}]
 
   t.add_quaff_scenario do
     caller.register
@@ -212,8 +212,8 @@ TestDefinition.new("ISC Interface - Third-party Registration - implicit registra
   as1 = t.add_as 5070
   as2 = t.add_as 5071
 
-  caller.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP", method: "REGISTER"}]
-  ep2.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5071;transport=TCP", method: "REGISTER"}]
+  caller.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP", method: "REGISTER"}]
+  ep2.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5071;transport=TCP", method: "REGISTER"}]
 
   t.add_quaff_scenario do
     caller.register
@@ -244,7 +244,7 @@ TestDefinition.new("ISC Interface - Redirect") do |t|
 
   as = t.add_as 5070
 
-  callee.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"}]
+  callee.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP"}]
 
   t.add_quaff_setup do
     caller.register
@@ -327,7 +327,7 @@ TestDefinition.new("ISC Interface - B2BUA") do |t|
 
   as = t.add_as 5070
 
-  callee.set_ifc [{server_name: "#{ENV['HOSTNAME']}:5070;transport=TCP"}]
+  callee.set_ifc [{server_name: "#{ENV['HOST_NAME']}:5070;transport=TCP"}]
 
   t.add_quaff_setup do
     caller.register


### PR DESCRIPTION
`$HOSTNAME` is normally the local host, so this causes tests to be run incorrectly. Change it to use `$HOST_NAME`.