### PR TITLE
[Reviewer: JA4] Fail test if there is an exception in the test-defined cleanup block

### DIFF
--- a/lib/test-definition.rb
+++ b/lib/test-definition.rb
@@ -450,7 +450,12 @@ class TestDefinition
       begin
         @quaff_cleanup_blk.call
       rescue => exception
-        puts "WARNING: Exception in quaff_cleanup_blk:\n - #{exception}"
+        if retval
+          retval = false
+          puts RedGreen::Color.red("Failed")
+        end
+
+        puts "Exception in quaff_cleanup_blk:\n - #{exception}"
       end
     end
 


### PR DESCRIPTION
If we hit an exception in the cleanup block, we should be failing the test - something has gone wrong with e.g. deregistration and we should highlight that with a test failure, instead of simply printing the exception to screen as we did before.

I haven't tested this code. I'm fairly confident that it should just work, but I suggest you try it out first @jack-atack. Also discuss it with the team to double check my assertion that hitting an issue in cleanup should always fail the test.