### PR TITLE
[Reviewer: Rob] Reliably test reg-event SUBSCRIBE / NOTIFY

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ./quaff/
   specs:
-    quaff (0.7.3)
+    quaff (0.7.4)
       abnf-parsing (>= 0.2.0)
       milenage (>= 0.1.0)
       system-getifaddrs (>= 0.2.1)

--- a/lib/quaff-monkey-patches.rb
+++ b/lib/quaff-monkey-patches.rb
@@ -49,9 +49,24 @@ module Quaff
     end
 
     def recv_200_and_notify
+
+      next_cseq = @last_CSeq
+
       # Store the routeset from the 200 OK, not the NOTIFY
       resp1 = recv_any_of [[200, true], ["NOTIFY", false]]
+
+      if resp1.method
+        next_cseq = @last_CSeq
+      end
+
       resp2 = recv_any_of [[200, true], ["NOTIFY", false]]
+
+      if resp2.method
+        next_cseq = @last_CSeq
+      end
+
+      # Restore the CSeq from the NOTIFY
+      @last_CSeq = next_cseq
 
       notify = resp1.method ? resp1 : resp2
       return notify

--- a/lib/tests/subscribe.rb
+++ b/lib/tests/subscribe.rb
@@ -37,6 +37,10 @@ TestDefinition.new("SUBSCRIBE - reg-event") do |t|
 
     call.send_response("200", "OK")
 
+    # If they registration arrives in the same second as the previous
+    # registration, we won't be notified. Sleep for one second to avoid this
+    sleep 1
+
     ep1.register # Re-registration
 
     notify2 = call.recv_request("NOTIFY")


### PR DESCRIPTION
Rob,

Two bugs in the current SUBSCRIBE / NOTIFY behaviour.

1) We expect to see the 200 OK to the SUBSCRIBE and the NOTIFY in either order. If we get the 200 OK to the SUBSCRIBE second, `@last_CSeq` in quaff represents the SUBSCRIBE, so sending the 200 OK to the NOTIFY sends something invalid. I've just added code to store off the CSeq for the NOTIFY and restore it.

2) If we re-register inside Sprout within 1 second, Sprout won't NOTIFY (as the registration hasn't been refreshed). It's a least debatable what the correct behaviour is here, but we aren't trying to hit this window condition, so this forces the code not to.

With these in place `rake test[rjw2.cw-ngv.com] TESTS="SUBSCRIBE - reg-event" REPEAT=100` doesn't hit either of these failures.