### PR TITLE
[Reviewer: Richard] Add emergency registration test

### DIFF
--- a/lib/quaff-endpoint.rb
+++ b/lib/quaff-endpoint.rb
@@ -18,7 +18,7 @@ require_relative 'quaff-monkey-patches'
 
 class QuaffEndpoint < Endpoint
   extend Forwarder
-  forward_all :incoming_call, :outgoing_call, :terminate, :register, :unregister, :msg_trace, :uri, :sdp_port, :sdp_socket, :msg_log, :local_port, :contact_header, :contact_header=, :no_new_calls?, :add_contact_param, to: :quaff
+  forward_all :incoming_call, :outgoing_call, :terminate, :register, :unregister, :msg_trace, :uri, :sdp_port, :sdp_socket, :msg_log, :local_port, :contact_header, :contact_header=, :no_new_calls?, :add_contact_param, :add_contact_uri_param, to: :quaff
   attr_reader :quaff
 
   def initialize(line_info, transport, endpoint_idx, use_instance_id=true)

--- a/lib/tests/basic-register.rb
+++ b/lib/tests/basic-register.rb
@@ -32,9 +32,12 @@ TestDefinition.new("Emergency Registration") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(caller.uri)
     call.send_request("REGISTER", "", { "Expires" => "3600" })
+    # The sos parameter means that this request should be accepted immediately
+    # without being challenged / authenticated.
     response_data = call.recv_response("200")
 
-    # Try to deregister -- this should be rejected.
+    # Try to deregister -- this should be rejected (as it is explicitly not
+    # supported by the S-CSCF).
     call.send_request("REGISTER", "", { "Expires" => "0" })
     response_data = call.recv_response("501")
   end

--- a/lib/tests/basic-register.rb
+++ b/lib/tests/basic-register.rb
@@ -23,7 +23,25 @@ TestDefinition.new("Basic Registration") do |t|
   t.add_quaff_cleanup do
     caller.unregister
   end
+end
 
+TestDefinition.new("Emergency Registration") do |t|
+  caller = t.add_endpoint
+  caller.add_contact_uri_param "sos", true
+
+  t.add_quaff_scenario do
+    call = caller.outgoing_call(caller.uri)
+    call.send_request("REGISTER", "", { "Expires" => "3600" })
+    response_data = call.recv_response("200")
+
+    # Try to deregister -- this should be rejected.
+    call.send_request("REGISTER", "", { "Expires" => "0" })
+    response_data = call.recv_response("501")
+  end
+
+  t.add_quaff_cleanup do
+    # Don't de-register.  It won't work.
+  end
 end
 
 TestDefinition.new("Multiple Identities") do |t|


### PR DESCRIPTION
Was also going to add a test for Registration expiry, but we already have one (that also checks that the correct notify is sent).   https://github.com/Metaswitch/clearwater-live-test/blob/master/lib/tests/subscribe.rb#L154-L220 