### PR TITLE
[Reviewer: Richard] Add Call Forking live tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ There are various modifiers you can use to determine which subset of tests you w
  - `ICSCF_HOSTNAME=<hostname>` - hostname of an I-CSCF in your deployment.
  - `EMERGENCY_REG=Y` - include tests that use emergency registrations. These will only work against Bono if Bono is run with the --allow-emergency-registration option enabled (which should not be enabled for live deployments as it represents a security risk)
  - `SHORT_REG=Y` - include tests that use short registrations (typically 3s). These tests will fail if your P-CSCF imposes a longer minimum registration interval.
+ - `PCSCF=<PROXY or B2BUA>` - whether the P-CSCF acts as a Proxy or a B2BUA. This affects the number of 180 Ringing responses seen in the Call Forking tests.
 
 For example, to run all the call barring tests (including the international number barring tests) on the test deployment, run:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There are various modifiers you can use to determine which subset of tests you w
  - `ICSCF_HOSTNAME=<hostname>` - hostname of an I-CSCF in your deployment.
  - `EMERGENCY_REG=Y` - include tests that use emergency registrations. These will only work against Bono if Bono is run with the --allow-emergency-registration option enabled (which should not be enabled for live deployments as it represents a security risk)
  - `SHORT_REG=Y` - include tests that use short registrations (typically 3s). These tests will fail if your P-CSCF imposes a longer minimum registration interval.
- - `PCSCF=<PROXY or B2BUA>` - whether the P-CSCF acts as a Proxy or a B2BUA. This affects the number of 180 Ringing responses seen in the Call Forking tests.
+ - `PCSCF=<PROXY or B2BUA>` - whether the P-CSCF acts as a Proxy or a B2BUA. This affects the number of 180 Ringing responses seen in the Call Forking tests. Defaults to `PROXY`, as that's how Bono behaves.
 
 For example, to run all the call barring tests (including the international number barring tests) on the test deployment, run:
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,10 @@
 task :default => [:test]
 task :test, :deployment do |t, args|
   require './lib/live-test'
+
+  # If no PCSCF is specified, assume it acts as a Proxy
+  ENV['PCSCF'] ||= "PROXY"
+
   ENV['TESTS'] ||= "*"
   run_tests(args.deployment, ENV['TESTS'])
 end

--- a/lib/tests/call-forking.rb
+++ b/lib/tests/call-forking.rb
@@ -1,0 +1,254 @@
+# @file call-forking.rb
+#
+# Copyright (C) Metaswitch Networks 2018
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+# Tests that a call made to a user with 2 bindings is forked correctly
+TestDefinition.new("Call Forking - Mainline") do |t|
+  caller = t.add_endpoint
+  callee_binding1 = t.add_endpoint
+  callee_binding2 = t.add_new_binding callee_binding1
+
+  ringing_barrier = Barrier.new(3)
+  answered_barrier = Barrier.new(3)
+
+  t.add_quaff_setup do
+    caller.register
+    callee_binding1.register
+    callee_binding2.register
+  end
+
+  t.add_quaff_scenario do
+    call = caller.outgoing_call(callee_binding1.uri)
+
+    # We only send a plain text body in this INVITE, not full SDP
+    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.recv_response("100")
+
+    # We expect to get 2 180 Ringing responses, as the call is forked
+    call.recv_response("180")
+    call.recv_response("180")
+    ringing_barrier.wait
+
+    # Save off Contact and routeset
+    call.recv_response_and_create_dialog("200")
+
+    call.new_transaction
+    call.send_request("ACK")
+    answered_barrier.wait()
+    sleep 1
+
+    call.new_transaction
+    call.send_request("BYE")
+    call.recv_response("200")
+    call.end_call
+  end
+
+  t.add_quaff_scenario do
+    call2 = callee_binding1.incoming_call
+
+    call2.recv_request("INVITE")
+    call2.send_response("100", "Trying")
+    call2.send_response("180", "Ringing")
+    ringing_barrier.wait
+
+    # This binding answers the call
+    call2.send_response("200", "OK", "hello world\r\n", nil, {"Content-Type" => "text/plain"})
+    call2.recv_request("ACK")
+    answered_barrier.wait()
+
+    call2.recv_request("BYE")
+    call2.send_response("200", "OK")
+    call2.end_call
+  end
+
+  t.add_quaff_scenario do
+    call3 = callee_binding2.incoming_call
+
+    original_invite = call3.recv_request("INVITE")
+    call3.send_response("100", "Trying")
+    call3.send_response("180", "Ringing")
+    ringing_barrier.wait
+
+    # The call is cancelled as the other binding picks up
+    call3.recv_request("CANCEL")
+    call3.send_response("200", "OK")
+
+    # assoc_with_msg ensures the CSeq of the 487 follows the INVITE
+    call3.assoc_with_msg(original_invite)
+    call3.send_response("487", "Request Terminated")
+    call3.recv_request("ACK")
+    call3.end_call
+
+    # Allow the rest of the test to proceed
+    answered_barrier.wait()
+
+  end
+
+  t.add_quaff_cleanup do
+    caller.unregister
+    callee_binding1.unregister
+    callee_binding2.unregister
+  end
+
+end
+
+# Tests that if one of two bindings is unresponsive, a call can still succeed to
+# the remaining binding
+TestDefinition.new("Call Forking - Endpoint offline") do |t|
+  caller = t.add_endpoint
+  callee_binding1 = t.add_endpoint
+  callee_binding2 = t.add_new_binding callee_binding1
+
+  ringing_barrier = Barrier.new(2)
+  answered_barrier = Barrier.new(2)
+
+  t.add_quaff_setup do
+    caller.register
+    callee_binding1.register
+    callee_binding2.register
+  end
+
+  t.add_quaff_scenario do
+    call = caller.outgoing_call(callee_binding1.uri)
+
+    # We only send a plain text body in this INVITE, not full SDP
+    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.recv_response("100")
+
+    # We expect to get only 1 180 Ringing response, as only one binding responds
+    call.recv_response("180")
+    ringing_barrier.wait
+
+    # Save off Contact and routeset
+    call.recv_response_and_create_dialog("200")
+
+    call.new_transaction
+    call.send_request("ACK")
+    answered_barrier.wait()
+    sleep 1
+
+    call.new_transaction
+    call.send_request("BYE")
+    call.recv_response("200")
+    call.end_call
+  end
+
+  t.add_quaff_scenario do
+    call2 = callee_binding1.incoming_call
+
+    call2.recv_request("INVITE")
+    call2.send_response("100", "Trying")
+    call2.send_response("180", "Ringing")
+    ringing_barrier.wait
+
+    # This binding answers the call
+    call2.send_response("200", "OK", "hello world\r\n", nil, {"Content-Type" => "text/plain"})
+    call2.recv_request("ACK")
+    answered_barrier.wait()
+
+    call2.recv_request("BYE")
+    call2.send_response("200", "OK")
+    call2.end_call
+  end
+
+  t.add_quaff_scenario do
+    call3 = callee_binding2.incoming_call
+
+    # Check that this binding receives the INVITE, but don't respond
+    call3.recv_request("INVITE")
+
+  end
+
+  t.add_quaff_cleanup do
+    caller.unregister
+    callee_binding1.unregister
+    callee_binding2.unregister
+  end
+
+end
+
+# Tests that if one of two bindings becomes unresponsive while in the ringing
+# state, a call can still succeed to the other binding
+TestDefinition.new("Call Forking - Endpoint offline while ringing") do |t|
+  caller = t.add_endpoint
+  callee_binding1 = t.add_endpoint
+  callee_binding2 = t.add_new_binding callee_binding1
+
+  ringing_barrier = Barrier.new(3)
+  answered_barrier = Barrier.new(2)
+
+  t.add_quaff_setup do
+    caller.register
+    callee_binding1.register
+    callee_binding2.register
+  end
+
+  t.add_quaff_scenario do
+    call = caller.outgoing_call(callee_binding1.uri)
+
+    # We only send a plain text body in this INVITE, not full SDP
+    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.recv_response("100")
+
+    # We expect to get 2 180 Ringing responses
+    call.recv_response("180")
+    call.recv_response("180")
+    ringing_barrier.wait
+
+    # Save off Contact and routeset
+    call.recv_response_and_create_dialog("200")
+
+    call.new_transaction
+    call.send_request("ACK")
+    answered_barrier.wait()
+    sleep 1
+
+    call.new_transaction
+    call.send_request("BYE")
+    call.recv_response("200")
+    call.end_call
+  end
+
+  t.add_quaff_scenario do
+    call2 = callee_binding1.incoming_call
+
+    call2.recv_request("INVITE")
+    call2.send_response("100", "Trying")
+    call2.send_response("180", "Ringing")
+    ringing_barrier.wait
+
+    # This binding answers the call
+    call2.send_response("200", "OK", "hello world\r\n", nil, {"Content-Type" => "text/plain"})
+    call2.recv_request("ACK")
+    answered_barrier.wait()
+
+    call2.recv_request("BYE")
+    call2.send_response("200", "OK")
+    call2.end_call
+  end
+
+  t.add_quaff_scenario do
+    call3 = callee_binding2.incoming_call
+
+    # Check that this binding receives the INVITE, gets to the Ringing state and
+    # then stops responding
+    call3.recv_request("INVITE")
+    call3.send_response("100", "Trying")
+    call3.send_response("180", "Ringing")
+    ringing_barrier.wait
+
+  end
+
+  t.add_quaff_cleanup do
+    caller.unregister
+    callee_binding1.unregister
+    callee_binding2.unregister
+  end
+
+end

--- a/lib/tests/call-forking.rb
+++ b/lib/tests/call-forking.rb
@@ -30,9 +30,14 @@ TestDefinition.new("Call Forking - Mainline") do |t|
     call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
     call.recv_response("100")
 
-    # We expect to get 2 180 Ringing responses, as the call is forked
+    # We expect to get one or two 180 responses, depending on whether the P-CSCF
+    # acts as a B2BUA or proxy
     call.recv_response("180")
-    call.recv_response("180")
+
+    if ENV['PCSCF'] == "PROXY"
+      call.recv_response("180")
+    end
+
     ringing_barrier.wait
 
     # Save off Contact and routeset
@@ -121,8 +126,9 @@ TestDefinition.new("Call Forking - Endpoint offline") do |t|
     call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
     call.recv_response("100")
 
-    # We expect to get only 1 180 Ringing response, as only one binding responds
+    # We expect only one 180 response, as only one binding responds to the caller
     call.recv_response("180")
+
     ringing_barrier.wait
 
     # Save off Contact and routeset
@@ -196,9 +202,14 @@ TestDefinition.new("Call Forking - Endpoint offline while ringing") do |t|
     call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
     call.recv_response("100")
 
-    # We expect to get 2 180 Ringing responses
+    # We expect to get one or two 180 responses, depending on whether the P-CSCF
+    # acts as a B2BUA or proxy
     call.recv_response("180")
-    call.recv_response("180")
+
+    if ENV['PCSCF'] == "PROXY"
+      call.recv_response("180")
+    end
+
     ringing_barrier.wait
 
     # Save off Contact and routeset

--- a/lib/tests/call-forking.rb
+++ b/lib/tests/call-forking.rb
@@ -26,8 +26,7 @@ TestDefinition.new("Call Forking - Mainline") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_binding1.uri)
 
-    # We only send a plain text body in this INVITE, not full SDP
-    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.send_request("INVITE")
     call.recv_response("100")
 
     # We expect to get one or two 180 responses, depending on whether the P-CSCF
@@ -63,7 +62,7 @@ TestDefinition.new("Call Forking - Mainline") do |t|
     ringing_barrier.wait
 
     # This binding answers the call
-    call2.send_response("200", "OK", "hello world\r\n", nil, {"Content-Type" => "text/plain"})
+    call2.send_response("200", "OK")
     call2.recv_request("ACK")
     answered_barrier.wait()
 
@@ -122,8 +121,7 @@ TestDefinition.new("Call Forking - Endpoint offline") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_binding1.uri)
 
-    # We only send a plain text body in this INVITE, not full SDP
-    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.send_request("INVITE")
     call.recv_response("100")
 
     # We expect only one 180 response, as only one binding responds to the caller
@@ -154,7 +152,7 @@ TestDefinition.new("Call Forking - Endpoint offline") do |t|
     ringing_barrier.wait
 
     # This binding answers the call
-    call2.send_response("200", "OK", "hello world\r\n", nil, {"Content-Type" => "text/plain"})
+    call2.send_response("200", "OK")
     call2.recv_request("ACK")
     answered_barrier.wait()
 
@@ -198,8 +196,7 @@ TestDefinition.new("Call Forking - Endpoint offline while ringing") do |t|
   t.add_quaff_scenario do
     call = caller.outgoing_call(callee_binding1.uri)
 
-    # We only send a plain text body in this INVITE, not full SDP
-    call.send_request("INVITE", "hello world\r\n", {"Content-Type" => "text/plain"})
+    call.send_request("INVITE")
     call.recv_response("100")
 
     # We expect to get one or two 180 responses, depending on whether the P-CSCF
@@ -235,7 +232,7 @@ TestDefinition.new("Call Forking - Endpoint offline while ringing") do |t|
     ringing_barrier.wait
 
     # This binding answers the call
-    call2.send_response("200", "OK", "hello world\r\n", nil, {"Content-Type" => "text/plain"})
+    call2.send_response("200", "OK")
     call2.recv_request("ACK")
     answered_barrier.wait()
 


### PR DESCRIPTION
Adds some live tests for Call Forking, namely:

1. Register 2 bindings for the callee, check that they both ring and that when one answers the other's call is cancelled
1. Register 2 bindings for the callee, but have one of them be unresponsive to the INVITE. Check that the call can still complete to the other
1. Register 2 bindings for the callee, but have one of the become unresponsive after sending a 180 response. Check that the call can still complete to the other

Verified that these pass on the staging system, and that the flows are correct in SAS

I've added a new option to the environment: `PCSCF=PROXY` or `PCSCF=B2BUA` which controls whether we expect one or two 180 Ringing responses on the Call Forking tests. It defaults to `PROXY` here, as that's how Bono behaves.
  